### PR TITLE
Minor: Tart isn't open source per the Open Source Definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ brew install swiftlint
 
 ## 🤨 Why is it named Tartelet?
 
-The app is named Tartelet because it builds upon [Tart](https://tart.run), an open-source CLI for managing macOS virtual machines. Tartelet makes it easy to run multiple virtual machines using Tart. The Danish word for "easy" is "let". "Tart" + "e" + "let" = "Tartelet" and [a "tartelet" is a traditional Danish food.](https://www.valdemarsro.dk/tarteletter-hoens-asparges/)
+The app is named Tartelet because it builds upon [Tart](https://tart.run), a source-available CLI for managing macOS virtual machines. Tartelet makes it easy to run multiple virtual machines using Tart. The Danish word for "easy" is "let". "Tart" + "e" + "let" = "Tartelet" and [a "tartelet" is a traditional Danish food.](https://www.valdemarsro.dk/tarteletter-hoens-asparges/)
 
 ## 🙏 Acknowledgements
 


### PR DESCRIPTION
From the [Fair Source License FAQ](https://fair.io): 

>"The Fair Source License is not an open-source license and doesn’t intend to be an open-source license."

While the source code to Tart is publicly viewable, the license limits the number of users, which doesn't comply with 
[The Open Source Definition](https://opensource.org/osd/) published by the Open Source Initiative.