### PR TITLE
Adds write(:toFileAt:) to FileSystem

### DIFF
--- a/Packages/FileSystem/Sources/FileSystem/FileSystem.swift
+++ b/Packages/FileSystem/Sources/FileSystem/FileSystem.swift
@@ -7,4 +7,5 @@ public protocol FileSystem {
     func copyItem(from sourceItemURL: URL, to destinationItemURL: URL) throws
     func contentsOfDirectory(at directoryURL: URL) throws -> [URL]
     func itemExists(at directoryURL: URL) -> Bool
+    func write(_ data: Data, toFileAt fileURL: URL) throws
 }

--- a/Packages/FileSystem/Sources/FileSystemDisk/FileSystemDisk.swift
+++ b/Packages/FileSystem/Sources/FileSystemDisk/FileSystemDisk.swift
@@ -40,4 +40,10 @@ public final class FileSystemDisk: FileSystem {
     public func itemExists(at directoryURL: URL) -> Bool {
         fileManager.fileExists(atPath: directoryURL.path)
     }
+
+    public func write(_ data: Data, toFileAt fileURL: URL) throws {
+        try NSFileCoordinator.coordinateWritingItem(at: fileURL, options: .forReplacing) { safeFileURL in
+            try data.write(to: safeFileURL, options: .atomic)
+        }
+    }
 }


### PR DESCRIPTION
`write(:toFileAt:)` can be used to safely writing to a file on disk and allows us to unit test the writes. This will be used when introducing logging.