### PR TITLE
Adds Logging package

### DIFF
--- a/Packages/FileSystem/Sources/FileSystem/FileSystem.swift
+++ b/Packages/FileSystem/Sources/FileSystem/FileSystem.swift
@@ -7,4 +7,5 @@ public protocol FileSystem {
     func copyItem(from sourceItemURL: URL, to destinationItemURL: URL) throws
     func contentsOfDirectory(at directoryURL: URL) throws -> [URL]
     func itemExists(at directoryURL: URL) -> Bool
+    func write(_ data: Data, toFileAt fileURL: URL) throws
 }

--- a/Packages/FileSystem/Sources/FileSystemDisk/FileSystemDisk.swift
+++ b/Packages/FileSystem/Sources/FileSystemDisk/FileSystemDisk.swift
@@ -40,4 +40,10 @@ public final class FileSystemDisk: FileSystem {
     public func itemExists(at directoryURL: URL) -> Bool {
         fileManager.fileExists(atPath: directoryURL.path)
     }
+
+    public func write(_ data: Data, toFileAt fileURL: URL) throws {
+        try NSFileCoordinator.coordinateWritingItem(at: fileURL, options: .forReplacing) { safeFileURL in
+            try data.write(to: safeFileURL, options: .atomic)
+        }
+    }
 }

--- a/Packages/Logging/.gitignore
+++ b/Packages/Logging/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Packages/Logging/Package.swift
+++ b/Packages/Logging/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Logging",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: "LogConsumer", targets: ["LogConsumer"]),
+        .library(name: "LogConsumerOSLog", targets: ["LogConsumerOSLog"]),
+        .library(name: "LogExporter", targets: ["LogExporter"]),
+        .library(name: "LogExporterLive", targets: ["LogExporterLive"]),
+        .library(name: "LogStore", targets: ["LogStore"]),
+        .library(name: "LogStoreOSLog", targets: ["LogStoreOSLog"])
+    ],
+    dependencies: [
+        .package(path: "../FileSystem")
+    ],
+    targets: [
+        .target(name: "LogConsumer"),
+        .target(name: "LogConsumerOSLog", dependencies: [
+            "LogConsumer"
+        ]),
+        .target(name: "LogExporter"),
+        .target(name: "LogExporterLive", dependencies: [
+            "FileSystem",
+            "LogExporter",
+            "LogStore"
+        ]),
+        .target(name: "LogStore"),
+        .target(name: "LogStoreOSLog", dependencies: [
+            "LogStore"
+        ]),
+        .testTarget(name: "LogExporterLiveTests", dependencies: [
+            "FileSystem",
+            "LogExporterLive",
+            "LogStore"
+        ])
+    ]
+)

--- a/Packages/Logging/Sources/LogConsumer/LogConsumer.swift
+++ b/Packages/Logging/Sources/LogConsumer/LogConsumer.swift
@@ -1,0 +1,6 @@
+public protocol LogConsumer {
+    func info(_ message: StaticString, _ args: CVarArg...)
+    func debug(_ message: StaticString, _ args: CVarArg...)
+    func error(_ message: StaticString, _ args: CVarArg...)
+    func fault(_ message: StaticString, _ args: CVarArg...)
+}

--- a/Packages/Logging/Sources/LogConsumerOSLog/LogConsumerOSLog.swift
+++ b/Packages/Logging/Sources/LogConsumerOSLog/LogConsumerOSLog.swift
@@ -1,0 +1,45 @@
+import LogConsumer
+import OSLog
+
+public struct LogConsumerOSLog: LogConsumer {
+    private let log: OSLog
+
+    public init(category: String) {
+        log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: category)
+    }
+
+    public func info(_ message: StaticString, _ args: CVarArg...) {
+        log(.info, message, args)
+    }
+
+    public func debug(_ message: StaticString, _ args: CVarArg...) {
+        log(.debug, message, args)
+    }
+
+    public func error(_ message: StaticString, _ args: CVarArg...) {
+        log(.error, message, args)
+    }
+
+    public func fault(_ message: StaticString, _ args: CVarArg...) {
+        log(.fault, message, args)
+    }
+}
+
+private extension LogConsumerOSLog {
+    private func log(_ logLevel: OSLogType, _ message: StaticString, _ args: CVarArg...) {
+        switch args.count {
+        case 1:
+            os_log(logLevel, log: log, message, args[0])
+        case 2:
+            os_log(logLevel, log: log, message, args[0], args[1])
+        case 3:
+            os_log(logLevel, log: log, message, args[0], args[1], args[2])
+        case 4:
+            os_log(logLevel, log: log, message, args[0], args[1], args[2], args[3])
+        case 5:
+            os_log(logLevel, log: log, message, args[0], args[1], args[2], args[3], args[4])
+        default:
+            os_log(logLevel, log: log, message)
+        }
+    }
+}

--- a/Packages/Logging/Sources/LogExporter/LogExporter.swift
+++ b/Packages/Logging/Sources/LogExporter/LogExporter.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol LogExporter {
+    func export() async throws -> URL
+}

--- a/Packages/Logging/Sources/LogExporterLive/LogExporterLive.swift
+++ b/Packages/Logging/Sources/LogExporterLive/LogExporterLive.swift
@@ -1,0 +1,38 @@
+import FileSystem
+import LogExporter
+import LogStore
+import OSLog
+
+enum LogExporterLiveError: LocalizedError {
+    case cannotCreateStringData
+
+    var errorDescription: String? {
+        switch self {
+        case .cannotCreateStringData:
+            return "Failed creating data to be written to disk"
+        }
+    }
+}
+
+public final actor LogExporterLive: LogExporter {
+    private let logStore: LogStore
+    private let fileSystem: FileSystem
+
+    public init(fileSystem: FileSystem, logStore: LogStore) {
+        self.fileSystem = fileSystem
+        self.logStore = logStore
+    }
+
+    public func export() async throws -> URL {
+        let messages = try logStore.readMessages()
+        let filename = Bundle.main.bundleIdentifier! + ".log"
+        let directoryURL = fileSystem.applicationSupportDirectoryURL
+        let fileURL = directoryURL.appending(path: filename, directoryHint: .notDirectory)
+        guard let data = messages.data(using: .utf8, allowLossyConversion: false) else {
+            throw LogExporterLiveError.cannotCreateStringData
+        }
+        try fileSystem.createDirectoryIfNeeded(at: directoryURL)
+        try fileSystem.write(data, toFileAt: fileURL)
+        return fileURL
+    }
+}

--- a/Packages/Logging/Sources/LogStore/LogStore.swift
+++ b/Packages/Logging/Sources/LogStore/LogStore.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol LogStore {
+    func readMessages() throws -> String
+}

--- a/Packages/Logging/Sources/LogStoreOSLog/LogEntryFormatter.swift
+++ b/Packages/Logging/Sources/LogStoreOSLog/LogEntryFormatter.swift
@@ -1,0 +1,33 @@
+import OSLog
+
+enum LogEntryFormatter {
+    static func format(_ entry: OSLogEntryLog) -> String {
+        [
+            entry.date.formatted(.iso8601),
+            "[\(entry.category)]",
+            "[\(entry.level.stringValue)]",
+            entry.composedMessage
+        ].joined(separator: " ")
+    }
+}
+
+private extension OSLogEntryLog.Level {
+    var stringValue: String {
+        switch self {
+        case .undefined:
+            return "Undefined"
+        case .debug:
+            return "Debug"
+        case .info:
+            return "Info"
+        case .notice:
+            return "Notice"
+        case .error:
+            return "Error"
+        case .fault:
+            return "Fault"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+}

--- a/Packages/Logging/Sources/LogStoreOSLog/LogStoreOSLog.swift
+++ b/Packages/Logging/Sources/LogStoreOSLog/LogStoreOSLog.swift
@@ -1,0 +1,15 @@
+import LogStore
+import OSLog
+
+public struct LogStoreOSLog: LogStore {
+    public init() {}
+
+    public func readMessages() throws -> String {
+        let store = try OSLogStore(scope: .currentProcessIdentifier)
+        return try store.getEntries()
+            .compactMap { $0 as? OSLogEntryLog }
+            .filter { $0.subsystem == Bundle.main.bundleIdentifier }
+            .map(LogEntryFormatter.format)
+            .joined(separator: "\n")
+    }
+}

--- a/Packages/Logging/Tests/LogExporterLiveTests/LogExporterLiveTests.swift
+++ b/Packages/Logging/Tests/LogExporterLiveTests/LogExporterLiveTests.swift
@@ -1,0 +1,49 @@
+import LogExporterLive
+import XCTest
+
+final class LogExporterLiveTests: XCTestCase {
+    func testItReadsMessagesFromLogStore() async throws {
+        let fileSystem = FileSystemMock()
+        let logStore = LogStoreMock()
+        let logExporter = LogExporterLive(fileSystem: fileSystem, logStore: logStore)
+        _ = try await logExporter.export()
+        XCTAssertTrue(logStore.didReadMessages)
+    }
+
+    func testItCreatesTheParentDirectory() async throws {
+        let fileSystem = FileSystemMock()
+        let logStore = LogStoreMock()
+        let logExporter = LogExporterLive(fileSystem: fileSystem, logStore: logStore)
+        _ = try await logExporter.export()
+        XCTAssertNotNil(fileSystem.createdDirectoryURL)
+    }
+
+    func testItWritesMessagesToDisk() async throws {
+        let fileSystem = FileSystemMock()
+        let logStore = LogStoreMock()
+        let logExporter = LogExporterLive(fileSystem: fileSystem, logStore: logStore)
+        _ = try await logExporter.export()
+        XCTAssertNotNil(fileSystem.writtenFileURL)
+    }
+
+    func testWrittenMessagesIsSameAsMessagesInLogStore() async throws {
+        let messages = "Hello world!"
+        let expectedData = messages.data(using: .utf8, allowLossyConversion: false)!
+        let fileSystem = FileSystemMock()
+        let logStore = LogStoreMock(messages: messages)
+        let logExporter = LogExporterLive(fileSystem: fileSystem, logStore: logStore)
+        _ = try await logExporter.export()
+        XCTAssertEqual(fileSystem.writtenData, expectedData)
+    }
+
+    func testItWritesToApplicationSupportDirectory() async throws {
+        let fileSystem = FileSystemMock()
+        let logStore = LogStoreMock()
+        let logExporter = LogExporterLive(fileSystem: fileSystem, logStore: logStore)
+        let fileURL = try await logExporter.export()
+        XCTAssert(
+            fileURL.absoluteString.hasPrefix(fileSystem.applicationSupportDirectoryURL.absoluteString),
+            "File path should be within the Application Support directory"
+        )
+    }
+}

--- a/Packages/Logging/Tests/LogExporterLiveTests/Mock/FileSystemMock.swift
+++ b/Packages/Logging/Tests/LogExporterLiveTests/Mock/FileSystemMock.swift
@@ -1,0 +1,31 @@
+import FileSystem
+import Foundation
+
+final class FileSystemMock: FileSystem {
+    private(set) var createdDirectoryURL: URL?
+    private(set) var writtenData: Data?
+    private(set) var writtenFileURL: URL?
+
+    let applicationSupportDirectoryURL = URL(filePath: "/Mock/ApplicationSupport")
+
+    func createDirectoryIfNeeded(at directoryURL: URL) throws {
+        createdDirectoryURL = directoryURL
+    }
+
+    func removeItem(at itemURL: URL) throws {}
+
+    func copyItem(from sourceItemURL: URL, to destinationItemURL: URL) throws {}
+
+    func contentsOfDirectory(at directoryURL: URL) throws -> [URL] {
+        []
+    }
+
+    func itemExists(at directoryURL: URL) -> Bool {
+        false
+    }
+
+    func write(_ data: Data, toFileAt fileURL: URL) throws {
+        writtenData = data
+        writtenFileURL = fileURL
+    }
+}

--- a/Packages/Logging/Tests/LogExporterLiveTests/Mock/LogStoreMock.swift
+++ b/Packages/Logging/Tests/LogExporterLiveTests/Mock/LogStoreMock.swift
@@ -1,0 +1,16 @@
+import LogStore
+
+final class LogStoreMock: LogStore {
+    private(set) var didReadMessages = false
+
+    private var messages: String
+
+    init(messages: String = "Hello world!") {
+        self.messages = messages
+    }
+
+    func readMessages() throws -> String {
+        didReadMessages = true
+        return messages
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -36,6 +36,18 @@ targets:
         product: Keychain
       - package: Keychain
         product: KeychainLive
+      - package: Logging
+        product: LogConsumer
+      - package: Logging
+        product: LogConsumerOSLog
+      - package: Logging
+        product: LogExporter
+      - package: Logging
+        product: LogExporterLive
+      - package: Logging
+        product: LogStore
+      - package: Logging
+        product: LogStoreOSLog
       - package: MenuBar
         product: MenuBarItem
       - package: Networking
@@ -81,6 +93,7 @@ localPackages:
   - Packages/FileSystem
   - Packages/GitHub
   - Packages/Keychain
+  - Packages/Logging
   - Packages/MenuBar
   - Packages/Networking
   - Packages/Settings


### PR DESCRIPTION
Adds the Logging package which contains all our functionality related to logging. At a high level, the package contains the following types:

- **LogConsumer**: An object that can receive log messages. Would ideally have been named Logger but I opted to a different name to avoid collisions with [the standard Logger type](https://developer.apple.com/documentation/os/logger).
- **LogStore**: An object that stores log messages. The LogExporter reads messages from the store.
- **LogExporter**: An object that can export messages.