### PR TITLE
Adds setting to select Tart home folder

### DIFF
--- a/Packages/Settings/Sources/SettingsStore/SettingsStore.swift
+++ b/Packages/Settings/Sources/SettingsStore/SettingsStore.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public final class SettingsStore: ObservableObject {
     private enum AppStorageKey {
         static let applicationUIMode = "applicationUIMode"
+        static let tartHomeFolderURL = "tartHomeFolderURL"
         static let virtualMachine = "virtualMachine"
         static let numberOfVirtualMachines = "numberOfVirtualMachines"
         static let startVirtualMachinesOnLaunch = "startVirtualMachinesOnLaunch"
@@ -14,6 +15,8 @@ public final class SettingsStore: ObservableObject {
 
     @AppStorage(AppStorageKey.applicationUIMode)
     public var applicationUIMode: ApplicationUIMode = .dockAndMenuBar
+    @AppStorage(AppStorageKey.tartHomeFolderURL)
+    public var tartHomeFolderURL: URL?
     @AppStorage(AppStorageKey.virtualMachine)
     public var virtualMachine: VirtualMachine = .unknown
     @AppStorage(AppStorageKey.numberOfVirtualMachines)

--- a/Packages/Settings/Sources/SettingsUI/Internal/L10n.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/L10n.swift
@@ -61,12 +61,14 @@ internal enum L10n {
       }
     }
     internal enum VirtualMachine {
-      /// Amount of Virtual Machines
-      internal static let count = L10n.tr("Localizable", "settings.virtual_machine.count", fallback: "Amount of Virtual Machines")
+      /// Amount
+      internal static let count = L10n.tr("Localizable", "settings.virtual_machine.count", fallback: "Amount")
       /// Use the Tart CLI to create a virtual machine.
       internal static let noVirtualMachinesAvailable = L10n.tr("Localizable", "settings.virtual_machine.no_virtual_machines_available", fallback: "Use the Tart CLI to create a virtual machine.")
       /// Start Virtual Machines on App Launch
       internal static let startVirtualMachinesOnAppLaunch = L10n.tr("Localizable", "settings.virtual_machine.start_virtual_machines_on_app_launch", fallback: "Start Virtual Machines on App Launch")
+      /// Tart Home
+      internal static let tartHomeFolder = L10n.tr("Localizable", "settings.virtual_machine.tart_home_folder", fallback: "Tart Home")
       /// Unknown
       internal static let unknown = L10n.tr("Localizable", "settings.virtual_machine.unknown", fallback: "Unknown")
       internal enum Count {
@@ -74,6 +76,16 @@ internal enum L10n {
         internal static let one = L10n.tr("Localizable", "settings.virtual_machine.count.one", fallback: "One")
         /// Two
         internal static let two = L10n.tr("Localizable", "settings.virtual_machine.count.two", fallback: "Two")
+      }
+      internal enum TartHomeFolder {
+        /// Value of the TART_HOME environment variable.
+        internal static let footer = L10n.tr("Localizable", "settings.virtual_machine.tart_home_folder.footer", fallback: "Value of the TART_HOME environment variable.")
+        /// ~/.tart
+        internal static let placeholder = L10n.tr("Localizable", "settings.virtual_machine.tart_home_folder.placeholder", fallback: "~/.tart")
+        /// Reset to Default
+        internal static let resetToDefault = L10n.tr("Localizable", "settings.virtual_machine.tart_home_folder.reset_to_default", fallback: "Reset to Default")
+        /// Select Folder
+        internal static let selectFolder = L10n.tr("Localizable", "settings.virtual_machine.tart_home_folder.select_folder", fallback: "Select Folder")
       }
     }
   }

--- a/Packages/Settings/Sources/SettingsUI/Internal/SettingsView.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/SettingsView.swift
@@ -56,6 +56,7 @@ struct SettingsView: View {
                     Asset.githubActions.swiftUIImage
                 }
             }
-        }.frame(width: 450, height: 250)
+        }
+        .frame(minWidth: 450, maxWidth: 550, minHeight: 250, maxHeight: 300)
     }
 }

--- a/Packages/Settings/Sources/SettingsUI/Internal/VirtualMachineSettings/TartHomeFolderPicker.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/VirtualMachineSettings/TartHomeFolderPicker.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct TartHomeFolderPicker: View {
+    @Binding private var folderURL: URL?
+    private let isEnabled: Bool
+    @State private var folderPath = ""
+
+    init(folderURL: Binding<URL?>, isEnabled: Bool) {
+        self._folderURL = folderURL
+        self.isEnabled = isEnabled
+        folderPath = folderURL.wrappedValue?.path() ?? ""
+    }
+
+    var body: some View {
+        LabeledContent {
+            VStack(alignment: .leading) {
+                HStack {
+                    TextField(
+                        L10n.Settings.VirtualMachine.tartHomeFolder,
+                        text: $folderPath,
+                        prompt: Text(L10n.Settings.VirtualMachine.TartHomeFolder.placeholder)
+                    )
+                    .labelsHidden()
+                    .disabled(true)
+                    Button {
+                        folderURL = nil
+                    } label: {
+                        Text(L10n.Settings.VirtualMachine.TartHomeFolder.resetToDefault)
+                    }.disabled(!isEnabled)
+                    Button {
+                        if let selectedFolderURL = presentOpenPanel() {
+                            Task {
+                                folderURL = selectedFolderURL
+                            }
+                        }
+                    } label: {
+                        Text(L10n.Settings.VirtualMachine.TartHomeFolder.selectFolder)
+                    }.disabled(!isEnabled)
+                }
+                Text(L10n.Settings.VirtualMachine.TartHomeFolder.footer)
+                    .multilineTextAlignment(.leading)
+                    .foregroundColor(.secondary)
+            }
+        } label: {
+            Text(L10n.Settings.VirtualMachine.tartHomeFolder)
+        }
+        .onChange(of: folderURL) { _ in
+            folderPath = folderURL?.path() ?? ""
+        }
+    }
+}
+
+private extension TartHomeFolderPicker {
+    private func presentOpenPanel() -> URL? {
+        let openPanel = NSOpenPanel()
+        openPanel.allowedContentTypes = [.folder]
+        openPanel.allowsMultipleSelection = false
+        openPanel.canChooseDirectories = true
+        openPanel.canChooseFiles = false
+        let response = openPanel.runModal()
+        return response == .OK ? openPanel.url : nil
+    }
+}

--- a/Packages/Settings/Sources/SettingsUI/Internal/VirtualMachineSettings/VirtualMachineSettingsView.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/VirtualMachineSettings/VirtualMachineSettingsView.swift
@@ -12,6 +12,13 @@ struct VirtualMachineSettingsView: View {
 
     var body: some View {
         Form {
+            TartHomeFolderPicker(
+                folderURL: $settingsStore.tartHomeFolderURL,
+                isEnabled: viewModel.isSettingsEnabled
+            )
+            Spacer().frame(height: 20)
+            Divider()
+            Spacer().frame(height: 20)
             VirtualMachinePicker(
                 selection: $settingsStore.virtualMachine,
                 virtualMachineNames: viewModel.virtualMachineNames,
@@ -31,6 +38,11 @@ struct VirtualMachineSettingsView: View {
         .padding()
         .task {
             await viewModel.refreshVirtualMachines()
+        }
+        .onChange(of: settingsStore.tartHomeFolderURL) { _ in
+            Task {
+                await viewModel.refreshVirtualMachines()
+            }
         }
     }
 }

--- a/Packages/Settings/Sources/SettingsUI/Supporting files/Localizable.strings
+++ b/Packages/Settings/Sources/SettingsUI/Supporting files/Localizable.strings
@@ -5,10 +5,15 @@
 "settings.general.application_ui_mode.dock_and_menu_bar" = "Dock and Menu Bar";
 "settings.general.export_logs" = "Export Logs...";
 
+"settings.virtual_machine.tart_home_folder" = "Tart Home";
+"settings.virtual_machine.tart_home_folder.select_folder" = "Select Folder";
+"settings.virtual_machine.tart_home_folder.reset_to_default" = "Reset to Default";
+"settings.virtual_machine.tart_home_folder.placeholder" = "~/.tart";
+"settings.virtual_machine.tart_home_folder.footer" = "Value of the TART_HOME environment variable.";
 "settings.virtual_machine" = "Virtual Machine";
 "settings.virtual_machine.unknown" = "Unknown";
 "settings.virtual_machine.no_virtual_machines_available" = "Use the Tart CLI to create a virtual machine.";
-"settings.virtual_machine.count" = "Amount of Virtual Machines";
+"settings.virtual_machine.count" = "Amount";
 "settings.virtual_machine.count.one" = "One";
 "settings.virtual_machine.count.two" = "Two";
 "settings.virtual_machine.start_virtual_machines_on_app_launch" = "Start Virtual Machines on App Launch";

--- a/Packages/Shell/Sources/Shell/Shell.swift
+++ b/Packages/Shell/Sources/Shell/Shell.swift
@@ -16,7 +16,11 @@ public struct Shell {
     public init() {}
 
     @discardableResult
-    public func runExecutable(atPath executablePath: String, withArguments arguments: [String]) async throws -> String {
+    public func runExecutable(
+        atPath executablePath: String,
+        withArguments arguments: [String],
+        environment: [String: String]? = nil
+    ) async throws -> String {
         let process = Process()
         let sendableProcess = SendableProcess(process)
         return try await withTaskCancellationHandler {
@@ -25,6 +29,7 @@ public struct Shell {
             process.arguments = arguments
             process.launchPath = executablePath
             process.standardInput = nil
+            process.environment = environment
             process.launch()
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()

--- a/Packages/Tart/Sources/Tart/Tart.swift
+++ b/Packages/Tart/Sources/Tart/Tart.swift
@@ -1,9 +1,17 @@
 import Shell
 
 public struct Tart {
+    private let homeProvider: TartHomeProvider
     private let shell: Shell
+    private var environment: [String: String]? {
+        guard let homeFolderURL = homeProvider.homeFolderURL else {
+            return nil
+        }
+        return ["TART_HOME": homeFolderURL.absoluteString]
+    }
 
-    public init(shell: Shell) {
+    public init(homeProvider: TartHomeProvider, shell: Shell) {
+        self.homeProvider = homeProvider
         self.shell = shell
     }
 
@@ -32,6 +40,6 @@ private extension Tart {
     private func executeCommand(withArguments arguments: [String]) async throws -> String {
         let locator = TartLocator(shell: shell)
         let filePath = try locator.locate()
-        return try await shell.runExecutable(atPath: filePath, withArguments: arguments)
+        return try await shell.runExecutable(atPath: filePath, withArguments: arguments, environment: environment)
     }
 }

--- a/Packages/Tart/Sources/Tart/TartHomeProvider.swift
+++ b/Packages/Tart/Sources/Tart/TartHomeProvider.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol TartHomeProvider {
+    var homeFolderURL: URL? { get }
+}

--- a/Tartelet/Sources/Composition/SettingsTartHomeProvider.swift
+++ b/Tartelet/Sources/Composition/SettingsTartHomeProvider.swift
@@ -1,0 +1,11 @@
+import Foundation
+import SettingsStore
+import Tart
+
+struct SettingsTartHomeProvider: TartHomeProvider {
+    var homeFolderURL: URL? {
+        settingsStore.tartHomeFolderURL
+    }
+
+    let settingsStore: SettingsStore
+}

--- a/Tartelet/Sources/CompositionRoot.swift
+++ b/Tartelet/Sources/CompositionRoot.swift
@@ -150,7 +150,11 @@ private extension CompositionRoot {
     private static let settingsStore = SettingsStore()
 
     private static var tart: Tart {
-        Tart(shell: shell)
+        Tart(homeProvider: tartHomeProvider, shell: shell)
+    }
+
+    private static var tartHomeProvider: TartHomeProvider {
+        SettingsTartHomeProvider(settingsStore: settingsStore)
     }
 
     private static var shell: Shell {


### PR DESCRIPTION
Adds a setting to specify Tart's home folder. The path is passed to the TART_HOME environment variable when invoking Tart.

This enables us to store Tart's virtual machines on an external drive that's connected to the host machine.

<img width="589" alt="Screenshot 2023-06-19 at 16 56 27" src="https://github.com/shapehq/tartelet/assets/830995/3310228c-f4b9-4be3-a543-9ce07f36ad8d">
