### PR TITLE
Fixes bug when colon character is in virtual machine name

### DIFF
--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
@@ -31,7 +31,7 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
     public var directoryURL: URL {
         fileSystem
             .applicationSupportDirectoryURL
-            .appending(path: virtualMachineName, directoryHint: .isDirectory)
+            .appending(path: virtualMachineName.replacingOccurrences(of: ":", with: "_"), directoryHint: .isDirectory)
     }
 
     private let fileSystem: FileSystem


### PR DESCRIPTION
This fixes issue #38. The colon character is used as a separator in tart's share command.