### PR TITLE
Add possibility to configure a runner group

### DIFF
--- a/Packages/Settings/Sources/SettingsStore/SettingsStore.swift
+++ b/Packages/Settings/Sources/SettingsStore/SettingsStore.swift
@@ -11,6 +11,7 @@ public final class SettingsStore: ObservableObject {
         static let startVirtualMachinesOnLaunch = "startVirtualMachinesOnLaunch"
         static let gitHubPrivateKeyName = "gitHubPrivateKeyName"
         static let gitHubRunnerLabels = "gitHubRunnerLabels"
+        static let gitHubRunnerGroup = "gitHubRunnerGroup"
     }
 
     @AppStorage(AppStorageKey.applicationUIMode)
@@ -27,6 +28,8 @@ public final class SettingsStore: ObservableObject {
     public var gitHubPrivateKeyName: String?
     @AppStorage(AppStorageKey.gitHubRunnerLabels)
     public var gitHubRunnerLabels = "tartelet"
+    @AppStorage(AppStorageKey.gitHubRunnerGroup)
+    public var gitHubRunnerGroup = ""
 
     public init() {}
 

--- a/Packages/Settings/Sources/SettingsUI/Internal/GitHubRunnerSettings/GitHubRunnerSettingsView.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/GitHubRunnerSettings/GitHubRunnerSettingsView.swift
@@ -18,6 +18,13 @@ struct GitHubRunnerSettingsView: View {
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
                 .foregroundColor(.secondary)
+
+            TextField(L10n.Settings.GithubRunner.group, text: $viewModel.group)
+                .disabled(!viewModel.isSettingsEnabled)
+            Text(L10n.Settings.GithubRunner.Group.footer)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+                .foregroundColor(.secondary)
         }
         .padding()
     }

--- a/Packages/Settings/Sources/SettingsUI/Internal/GitHubRunnerSettings/GitHubRunnerSettingsViewModel.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/GitHubRunnerSettings/GitHubRunnerSettingsViewModel.swift
@@ -6,6 +6,7 @@ import SwiftUI
 final class GitHubRunnerSettingsViewModel: ObservableObject {
     let settingsStore: SettingsStore
     @Published var labels: String = ""
+    @Published var group: String = ""
     @Published private(set) var isSettingsEnabled = true
 
     private var cancellables: Set<AnyCancellable> = []
@@ -16,6 +17,9 @@ final class GitHubRunnerSettingsViewModel: ObservableObject {
         isSettingsEnabled.assign(to: \.isSettingsEnabled, on: self).store(in: &cancellables)
         $labels.debounce(for: 0.5, scheduler: DispatchQueue.main).dropFirst().sink { [weak self] labels in
             self?.settingsStore.gitHubRunnerLabels = labels
+        }.store(in: &cancellables)
+        $group.debounce(for: 0.5, scheduler: DispatchQueue.main).dropFirst().sink { [weak self] group in
+            self?.settingsStore.gitHubRunnerGroup = group
         }.store(in: &cancellables)
     }
 }

--- a/Packages/Settings/Sources/SettingsUI/Internal/L10n.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/L10n.swift
@@ -53,8 +53,14 @@ internal enum L10n {
       }
     }
     internal enum GithubRunner {
+      /// Group
+      internal static let group = L10n.tr("Localizable", "settings.github_runner.group", fallback: "Group")
       /// Labels
       internal static let labels = L10n.tr("Localizable", "settings.github_runner.labels", fallback: "Labels")
+      internal enum Group {
+        /// Name of the runner group.
+        internal static let footer = L10n.tr("Localizable", "settings.github_runner.group.footer", fallback: "Name of the runner group.")
+      }
       internal enum Labels {
         /// Comma-separated list of labels.
         internal static let footer = L10n.tr("Localizable", "settings.github_runner.labels.footer", fallback: "Comma-separated list of labels.")

--- a/Packages/Settings/Sources/SettingsUI/Supporting files/Localizable.strings
+++ b/Packages/Settings/Sources/SettingsUI/Supporting files/Localizable.strings
@@ -30,3 +30,5 @@
 "settings.github_runner" = "Runner";
 "settings.github_runner.labels" = "Labels";
 "settings.github_runner.labels.footer" = "Comma-separated list of labels.";
+"settings.github_runner.group" = "Group";
+"settings.github_runner.group.footer" = "Name of the runner group.";

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
@@ -1,7 +1,6 @@
 #!/bin/zsh
 PRE_RUN_SCRIPT="pre-run.sh"
 POST_RUN_SCRIPT="post-run.sh"
-RUNNER_GROUP=""
 ACTIONS_RUNNER_ARCHIVE=./actions-runner.tar.gz
 ACTIONS_RUNNER_DIRECTORY=~/actions-runner
 WORK_DIRECTORY=_work
@@ -10,6 +9,7 @@ RUNNER_URL_FILE=./RUNNER_URL
 RUNNER_TOKEN_FILE=./RUNNER_TOKEN
 RUNNER_DOWNLOAD_URL_FILE=./RUNNER_DOWNLOAD_URL
 RUNNER_LABELS_FILE=./RUNNER_LABELS
+RUNNER_GROUP_FILE=./RUNNER_GROUP
 
 # Ensure the virtual machine is restarted when a job is done.
 set -e pipefail
@@ -42,6 +42,10 @@ if [ ! -f $RUNNER_LABELS_FILE ]; then
   echo "The RUNNER_LABELS file was not found"
   exit 1
 fi
+if [ ! -f $RUNNER_GROUP_FILE ]; then
+  echo "The RUNNER_GROUP file was not found"
+  exit 1
+fi
 
 # Read constants from files
 RUNNER_NAME=$(<./RUNNER_NAME)
@@ -49,6 +53,7 @@ RUNNER_URL=$(<./RUNNER_URL)
 RUNNER_TOKEN=$(<./RUNNER_TOKEN)
 RUNNER_DOWNLOAD_URL=$(<./RUNNER_DOWNLOAD_URL)
 RUNNER_LABELS=$(<./RUNNER_LABELS)
+RUNNER_GROUP=$(<./RUNNER_GROUP)
 
 # Download the runner if the archive does not already exist
 if [ ! -f $ACTIONS_RUNNER_ARCHIVE ]; then

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
@@ -26,6 +26,7 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         static let runnerToken = "RUNNER_TOKEN"
         static let runnerDownloadURL = "RUNNER_DOWNLOAD_URL"
         static let runnerLabels = "RUNNER_LABELS"
+        static let runnerGroup = "RUNNER_GROUP"
     }
 
     public var directoryURL: URL {
@@ -41,6 +42,7 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
     private let editorResourcesDirectoryURL: URL
     private let virtualMachineName: String
     private let runnerLabels: String
+    private let runnerGroup: String
 
     public init(
         fileSystem: FileSystem,
@@ -49,7 +51,8 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         resourcesCopier: VirtualMachineResourcesCopier,
         editorResourcesDirectoryURL: URL,
         virtualMachineName: String,
-        runnerLabels: String
+        runnerLabels: String,
+        runnerGroup: String
     ) {
         self.fileSystem = fileSystem
         self.gitHubService = gitHubService
@@ -58,6 +61,7 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         self.editorResourcesDirectoryURL = editorResourcesDirectoryURL
         self.virtualMachineName = virtualMachineName
         self.runnerLabels = runnerLabels
+        self.runnerGroup = runnerGroup
     }
 
     public func createResourcesIfNeeded() async throws {
@@ -74,11 +78,13 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         let runnerTokenFileURL = directoryURL.appending(path: ResourceFilename.runnerToken)
         let runnerDownloadURLFileURL = directoryURL.appending(path: ResourceFilename.runnerDownloadURL)
         let runnerLabelsFileURL = directoryURL.appending(path: ResourceFilename.runnerLabels)
+        let runnerGroupFileURL = directoryURL.appending(path: ResourceFilename.runnerGroup)
         try virtualMachineName.write(to: runnerNameFileURL, atomically: true, encoding: .utf8)
         try runnerURL.absoluteString.write(to: runnerURLFileURL, atomically: true, encoding: .utf8)
         try runnerToken.rawValue.write(to: runnerTokenFileURL, atomically: true, encoding: .utf8)
         try runnerDownloadURL.absoluteString.write(to: runnerDownloadURLFileURL, atomically: true, encoding: .utf8)
         try runnerLabels.write(to: runnerLabelsFileURL, atomically: true, encoding: .utf8)
+        try runnerGroup.write(to: runnerGroupFileURL, atomically: true, encoding: .utf8)
         if let resourcesDirectoryURL = Bundle.module.resourceURL?.appending(path: "Resources") {
             try resourcesCopier.copyResources(from: resourcesDirectoryURL, to: directoryURL)
         }

--- a/Tartelet/Sources/Composition/EphemeralVirtualMachineResourcesServiceFactory.swift
+++ b/Tartelet/Sources/Composition/EphemeralVirtualMachineResourcesServiceFactory.swift
@@ -23,7 +23,8 @@ struct EphemeralVirtualMachineResourcesServiceFactory: VirtualMachineResourcesSe
             resourcesCopier: resourcesCopier,
             editorResourcesDirectoryURL: editorResourcesDirectoryURL,
             virtualMachineName: virtualMachineName,
-            runnerLabels: settingsStore.gitHubRunnerLabels
+            runnerLabels: settingsStore.gitHubRunnerLabels,
+            runnerGroup: settingsStore.gitHubRunnerGroup
         )
     }
 }


### PR DESCRIPTION
In our organization, we need to manage access to our runners using Github's [runner groups](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/managing-access-to-self-hosted-runners-using-groups#about-runner-groups) feature.

I noticed that the `config.sh` script invocation already sets the `--runnergroup` option required to do this, but there's no place in the UI to set it, so I created it!

<img width="662" alt="Screenshot 2023-08-17 at 16 40 25" src="https://github.com/shapehq/tartelet/assets/16212751/9bcdf0e2-35a2-40c2-a56a-255c5d35f594">

Please let me know if you have any feedback!