### PR TITLE
Add ability to register runners under repository for individual accounts

### DIFF
--- a/Packages/GitHub/Sources/GitHubCredentialsStore/GitHubCredentialsStore.swift
+++ b/Packages/GitHub/Sources/GitHubCredentialsStore/GitHubCredentialsStore.swift
@@ -2,9 +2,12 @@ import Foundation
 
 public protocol GitHubCredentialsStore: AnyObject {
     var organizationName: String? { get async }
+    var repositoryName: String? { get async }
+    var ownerName: String? { get async }
     var appId: String? { get async }
     var privateKey: Data? { get async }
     func setOrganizationName(_ organizationName: String?) async
+    func setRepository(_ repositoryName: String?, withOwner ownerName: String?) async
     func setAppID(_ appID: String?) async
     func setPrivateKey(_ privateKeyData: Data?) async
 }

--- a/Packages/GitHub/Sources/GitHubCredentialsStoreKeychain/GitHubCredentialsStoreKeychain.swift
+++ b/Packages/GitHub/Sources/GitHubCredentialsStoreKeychain/GitHubCredentialsStoreKeychain.swift
@@ -6,6 +6,8 @@ import RSAPrivateKey
 public final actor GitHubCredentialsStoreKeychain: GitHubCredentialsStore {
     private enum PasswordAccount {
         static let organizationName = "github.credentials.organizationName"
+        static let repositoryName = "github.credentials.repositoryName"
+        static let ownerName = "github.credentials.ownerName"
         static let appId = "github.credentials.appId"
     }
 
@@ -16,6 +18,16 @@ public final actor GitHubCredentialsStoreKeychain: GitHubCredentialsStore {
     public var organizationName: String? {
         get async {
             return await keychain.password(forAccount: PasswordAccount.organizationName, belongingToService: serviceName)
+        }
+    }
+    public var repositoryName: String? {
+        get async {
+            return await keychain.password(forAccount: PasswordAccount.repositoryName, belongingToService: serviceName)
+        }
+    }
+    public var ownerName: String? {
+        get async {
+            return await keychain.password(forAccount: PasswordAccount.ownerName, belongingToService: serviceName)
         }
     }
     public var appId: String? {
@@ -42,6 +54,18 @@ public final actor GitHubCredentialsStoreKeychain: GitHubCredentialsStore {
             _ = await keychain.setPassword(organizationName, forAccount: PasswordAccount.organizationName, belongingToService: serviceName)
         } else {
             await keychain.removePassword(forAccount: PasswordAccount.organizationName, belongingToService: serviceName)
+        }
+    }
+    public func setRepository(_ repositoryName: String?, withOwner ownerName: String?) async {
+        if let repositoryName {
+            _ = await keychain.setPassword(repositoryName, forAccount: PasswordAccount.repositoryName, belongingToService: serviceName)
+        } else {
+            await keychain.removePassword(forAccount: PasswordAccount.repositoryName, belongingToService: serviceName)
+        }
+        if let ownerName {
+            _ = await keychain.setPassword(ownerName, forAccount: PasswordAccount.ownerName, belongingToService: serviceName)
+        } else {
+            await keychain.removePassword(forAccount: PasswordAccount.ownerName, belongingToService: serviceName)
         }
     }
 

--- a/Packages/GitHub/Sources/GitHubService/GitHubRunnerScope.swift
+++ b/Packages/GitHub/Sources/GitHubService/GitHubRunnerScope.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum GitHubRunnerScope: String, CaseIterable {
+  case organization
+  case repo
+}

--- a/Packages/GitHub/Sources/GitHubService/GitHubService.swift
+++ b/Packages/GitHub/Sources/GitHubService/GitHubService.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 public protocol GitHubService {
-    func getAppAccessToken() async throws -> GitHubAppAccessToken
-    func getRunnerRegistrationToken(with appAccessToken: GitHubAppAccessToken) async throws -> GitHubRunnerRegistrationToken
-    func getRunnerDownloadURL(with appAccessToken: GitHubAppAccessToken) async throws -> URL
+    func getAppAccessToken(runnerScope: GitHubRunnerScope) async throws -> GitHubAppAccessToken
+    func getRunnerRegistrationToken(
+      with appAccessToken: GitHubAppAccessToken,
+      runnerScope: GitHubRunnerScope
+    ) async throws -> GitHubRunnerRegistrationToken
+    func getRunnerDownloadURL(with appAccessToken: GitHubAppAccessToken, runnerScope: GitHubRunnerScope) async throws -> URL
 }

--- a/Packages/Settings/Package.swift
+++ b/Packages/Settings/Package.swift
@@ -19,10 +19,12 @@ let package = Package(
     targets: [
         .target(name: "Settings"),
         .target(name: "SettingsStore", dependencies: [
+            .product(name: "GitHubService", package: "GitHub"),
             "Settings"
         ]),
         .target(name: "SettingsUI", dependencies: [
             .product(name: "GitHubCredentialsStore", package: "GitHub"),
+            .product(name: "GitHubService", package: "GitHub"),
             .product(name: "LogExporter", package: "Logging"),
             "Settings",
             "SettingsStore",

--- a/Packages/Settings/Sources/SettingsStore/SettingsStore.swift
+++ b/Packages/Settings/Sources/SettingsStore/SettingsStore.swift
@@ -1,4 +1,5 @@
 import Combine
+import GitHubService
 import Settings
 import SwiftUI
 
@@ -12,6 +13,7 @@ public final class SettingsStore: ObservableObject {
         static let gitHubPrivateKeyName = "gitHubPrivateKeyName"
         static let gitHubRunnerLabels = "gitHubRunnerLabels"
         static let gitHubRunnerGroup = "gitHubRunnerGroup"
+        static let githubRunnerScope = "githubRunnerScope"
     }
 
     @AppStorage(AppStorageKey.applicationUIMode)
@@ -30,6 +32,8 @@ public final class SettingsStore: ObservableObject {
     public var gitHubRunnerLabels = "tartelet"
     @AppStorage(AppStorageKey.gitHubRunnerGroup)
     public var gitHubRunnerGroup = ""
+    @AppStorage(AppStorageKey.githubRunnerScope)
+    public var githubRunnerScope: GitHubRunnerScope = .organization
 
     public init() {}
 

--- a/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubPrivateKeyPicker.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubPrivateKeyPicker.swift
@@ -12,37 +12,40 @@ struct GitHubPrivateKeyPicker: View {
     }
 
     var body: some View {
-        LabeledContent {
-            VStack {
-                HStack {
-                    TextField(
-                        L10n.Settings.Github.privateKey,
-                        text: $filename,
-                        prompt: Text(L10n.Settings.Github.PrivateKey.placeholder)
-                    )
-                    .labelsHidden()
-                    .disabled(true)
-                    Button {
-                        if let fileURL = presentOpenPanel() {
-                            onSelectFile(fileURL)
-                        }
-                    } label: {
-                        Text(L10n.Settings.Github.PrivateKey.selectFile)
-                    }.disabled(!isEnabled)
-                }
-                Text(L10n.Settings.Github.PrivateKey.scopes)
-                    .multilineTextAlignment(.center)
-                    .lineSpacing(4)
-                    .padding(8)
-                    .frame(maxWidth: .infinity)
-                    .foregroundColor(.secondary)
-                    .background {
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(.separator, lineWidth: 1)
+        VStack(spacing: 16) {
+            LabeledContent {
+                VStack {
+                    HStack {
+                        TextField(
+                            L10n.Settings.Github.privateKey,
+                            text: $filename,
+                            prompt: Text(L10n.Settings.Github.PrivateKey.placeholder)
+                        )
+                        .labelsHidden()
+                        .disabled(true)
+                        Button {
+                            if let fileURL = presentOpenPanel() {
+                                onSelectFile(fileURL)
+                            }
+                        } label: {
+                            Text(L10n.Settings.Github.PrivateKey.selectFile)
+                        }.disabled(!isEnabled)
                     }
+                }
+            } label: {
+                Text(L10n.Settings.Github.privateKey)
             }
-        } label: {
-            Text(L10n.Settings.Github.privateKey)
+
+            Text(L10n.Settings.Github.PrivateKey.scopes)
+                .multilineTextAlignment(.center)
+                .lineSpacing(4)
+                .padding(8)
+                .frame(maxWidth: .infinity)
+                .foregroundColor(.secondary)
+                .background {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(.separator, lineWidth: 1)
+                }
         }
     }
 }

--- a/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubSettingsView.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubSettingsView.swift
@@ -12,22 +12,42 @@ struct GitHubSettingsView: View {
 
     var body: some View {
         Form {
-            TextField(L10n.Settings.Github.organizationName, text: $viewModel.organizationName)
-                .disabled(!viewModel.isSettingsEnabled)
-            TextField(L10n.Settings.Github.appId, text: $viewModel.appId)
-                .disabled(!viewModel.isSettingsEnabled)
-            GitHubPrivateKeyPicker(filename: $viewModel.privateKeyName, isEnabled: viewModel.isSettingsEnabled) { fileURL in
-                Task {
-                    await viewModel.storePrivateKey(at: fileURL)
+            Section {
+                Picker(L10n.Settings.Github.runnerScope, selection: $viewModel.runnerScope) {
+                    ForEach(RunnerScope.allCases, id: \.self) { scope in
+                        Text(scope.rawValue.capitalized)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                switch viewModel.runnerScope {
+                case .organization:
+                    TextField(L10n.Settings.Github.organizationName, text: $viewModel.organizationName)
+                        .disabled(!viewModel.isSettingsEnabled)
+                case .repo:
+                    TextField(L10n.Settings.Github.ownerName, text: $viewModel.ownerName)
+                        .disabled(!viewModel.isSettingsEnabled)
+                    TextField(L10n.Settings.Github.repositoryName, text: $viewModel.repositoryName)
+                        .disabled(!viewModel.isSettingsEnabled)
                 }
             }
-            Button {
-                viewModel.openCreateApp()
-            } label: {
-                Text(L10n.Settings.Github.createApp)
+            Section {
+                TextField(L10n.Settings.Github.appId, text: $viewModel.appId)
+                    .disabled(!viewModel.isSettingsEnabled)
+                GitHubPrivateKeyPicker(filename: $viewModel.privateKeyName, isEnabled: viewModel.isSettingsEnabled) { fileURL in
+                    Task {
+                        await viewModel.storePrivateKey(at: fileURL)
+                    }
+                }
+                Button {
+                    viewModel.openCreateApp()
+                } label: {
+                    Text(L10n.Settings.Github.createApp)
+                }
+                .frame(maxWidth: .infinity, alignment: .trailing)
             }
         }
-        .padding()
+        .formStyle(.grouped)
         .task {
             await viewModel.loadCredentials()
         }

--- a/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubSettingsViewModel.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubSettingsViewModel.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import GitHubCredentialsStore
+import GitHubService
 import SettingsStore
 import SwiftUI
 
@@ -8,15 +9,18 @@ import SwiftUI
 final class GitHubSettingsViewModel: ObservableObject {
     let settingsStore: SettingsStore
     @Published var organizationName: String = ""
+    @Published var repositoryName: String = ""
+    @Published var ownerName: String = ""
     @Published var appId: String = ""
     @Published var privateKeyName = ""
+    @Published var runnerScope: GitHubRunnerScope
     @Published private(set) var isSettingsEnabled = true
 
     private let credentialsStore: GitHubCredentialsStore
     private var cancellables: Set<AnyCancellable> = []
     private var createAppURL: URL {
         var url = URL(string: "https://github.com")!
-        if !organizationName.isEmpty {
+        if !organizationName.isEmpty, case .organization = runnerScope {
             url = url.appending(path: "/organizations/\(organizationName)")
         }
         return url.appending(path: "/settings/apps")
@@ -25,17 +29,36 @@ final class GitHubSettingsViewModel: ObservableObject {
     init(settingsStore: SettingsStore, credentialsStore: GitHubCredentialsStore, isSettingsEnabled: AnyPublisher<Bool, Never>) {
         self.settingsStore = settingsStore
         self.credentialsStore = credentialsStore
+        self.runnerScope = settingsStore.githubRunnerScope
         isSettingsEnabled.assign(to: \.isSettingsEnabled, on: self).store(in: &cancellables)
-        $organizationName.debounce(for: 0.5, scheduler: DispatchQueue.main).nilIfEmpty().dropFirst().sink { [weak self] organizationName in
-            Task {
-                await self?.credentialsStore.setOrganizationName(organizationName)
-            }
-        }.store(in: &cancellables)
         $appId.debounce(for: 0.5, scheduler: DispatchQueue.main).nilIfEmpty().dropFirst().sink { [weak self] appId in
             Task {
                 await self?.credentialsStore.setAppID(appId)
             }
         }.store(in: &cancellables)
+        $runnerScope
+            .combineLatest(
+                $organizationName.nilIfEmpty(),
+                $ownerName.nilIfEmpty(),
+                $repositoryName.nilIfEmpty()
+            )
+            .debounce(for: 0.5, scheduler: DispatchQueue.main)
+            .dropFirst()
+            .sink { [weak self] runnerScope, organizationName, ownerName, repositoryName in
+                self?.settingsStore.githubRunnerScope = runnerScope
+                switch runnerScope {
+                case .organization:
+                    Task {
+                        await self?.credentialsStore.setOrganizationName(organizationName)
+                        await self?.credentialsStore.setRepository(nil, withOwner: nil)
+                    }
+                case .repo:
+                    Task {
+                        await self?.credentialsStore.setOrganizationName(nil)
+                        await self?.credentialsStore.setRepository(repositoryName, withOwner: ownerName)
+                    }
+                }
+            }.store(in: &cancellables)
     }
 
     func openCreateApp() {
@@ -58,11 +81,15 @@ final class GitHubSettingsViewModel: ObservableObject {
 
     func loadCredentials() async {
         organizationName = await credentialsStore.organizationName ?? ""
+        repositoryName = await credentialsStore.repositoryName ?? ""
+        ownerName = await credentialsStore.ownerName ?? ""
         appId = await credentialsStore.appId ?? ""
         let privateKey = await credentialsStore.privateKey
         privateKeyName = privateKey != nil ? settingsStore.gitHubPrivateKeyName ?? "" : ""
     }
 }
+
+typealias RunnerScope = GitHubRunnerScope
 
 private extension Publisher where Output == String {
     func nilIfEmpty() -> AnyPublisher<String?, Failure> {

--- a/Packages/Settings/Sources/SettingsUI/Internal/L10n.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/L10n.swift
@@ -40,8 +40,14 @@ internal enum L10n {
       internal static let createApp = L10n.tr("Localizable", "settings.github.create_app", fallback: "Create GitHub App")
       /// Organization Name
       internal static let organizationName = L10n.tr("Localizable", "settings.github.organization_name", fallback: "Organization Name")
+      /// Owner name
+      internal static let ownerName = L10n.tr("Localizable", "settings.github.owner_name", fallback: "Owner name")
       /// Private Key (PEM)
       internal static let privateKey = L10n.tr("Localizable", "settings.github.private_key", fallback: "Private Key (PEM)")
+      /// Repository name
+      internal static let repositoryName = L10n.tr("Localizable", "settings.github.repository_name", fallback: "Repository name")
+      /// Runner scope
+      internal static let runnerScope = L10n.tr("Localizable", "settings.github.runner_scope", fallback: "Runner scope")
       internal enum PrivateKey {
         /// Select a private key (PEM)
         internal static let placeholder = L10n.tr("Localizable", "settings.github.private_key.placeholder", fallback: "Select a private key (PEM)")

--- a/Packages/Settings/Sources/SettingsUI/Supporting files/Localizable.strings
+++ b/Packages/Settings/Sources/SettingsUI/Supporting files/Localizable.strings
@@ -20,6 +20,9 @@
 
 "settings.github" = "GitHub";
 "settings.github.organization_name" = "Organization Name";
+"settings.github.runner_scope" = "Runner scope";
+"settings.github.owner_name" = "Owner name";
+"settings.github.repository_name" = "Repository name";
 "settings.github.app_id" = "App ID";
 "settings.github.private_key" = "Private Key (PEM)";
 "settings.github.private_key.select_file" = "Select File";

--- a/Tartelet/Sources/Composition/EphemeralVirtualMachineResourcesServiceFactory.swift
+++ b/Tartelet/Sources/Composition/EphemeralVirtualMachineResourcesServiceFactory.swift
@@ -20,6 +20,7 @@ struct EphemeralVirtualMachineResourcesServiceFactory: VirtualMachineResourcesSe
             fileSystem: fileSystem,
             gitHubService: gitHubService,
             gitHubCredentialsStore: gitHubCredentialsStore,
+            runnerScope: settingsStore.githubRunnerScope,
             resourcesCopier: resourcesCopier,
             editorResourcesDirectoryURL: editorResourcesDirectoryURL,
             virtualMachineName: virtualMachineName,


### PR DESCRIPTION
This PR adds the ability to register runners for a repository of an individual account.
To be able to distinguish between runners for an organization and for repository of an individual account a new `GitHubRunnerScope` is added.

The "GitHub" tab in the settings is updated so both scope types can be configured, but only one scope can be active at the time (the style of the form page is a little bit changed, to try grouping together informations)

<img width="662" alt="Tartlet GitHub settings tab with 'Organization' scope selected" src="https://github.com/shapehq/tartelet/assets/111388/94af3225-b42e-44b5-9ddd-b23a87ee607d">

<img width="662" alt="Tartlet GitHub settings tab with 'Repo' scope selected" src="https://github.com/shapehq/tartelet/assets/111388/0487ad89-9b67-4cda-86f2-a2078f72bb67">

This changes are backward compatible as the default runner scope is `organization`; unfortunately I'm not able to test this changes on a real organization so a real test should be performed.

Fixes #5