### PR TITLE
Gently stops fleet of virtual machines

### DIFF
--- a/Packages/MenuBar/Sources/MenuBarItem/Internal/FleetMenuBarItem.swift
+++ b/Packages/MenuBar/Sources/MenuBarItem/Internal/FleetMenuBarItem.swift
@@ -13,19 +13,25 @@ struct FleetMenuBarItem: View {
     let onSelect: (Action) -> Void
 
     var body: some View {
-        if isFleetStarted {
+        if isStoppingFleet {
+            Button {} label: {
+                HStack {
+                    Image(systemName: "stop.fill")
+                    Text(L10n.MenuBarItem.VirtualMachines.stopping)
+                }
+            }.disabled(true)
+            Button {} label: {
+                Text(L10n.MenuBarItem.VirtualMachines.stoppingInfo)
+            }.disabled(true)
+        } else if isFleetStarted {
             Button {
                 onSelect(.stop)
             } label: {
                 HStack {
                     Image(systemName: "stop.fill")
-                    if isStoppingFleet {
-                        Text(L10n.MenuBarItem.VirtualMachines.stopping)
-                    } else {
-                        Text(L10n.MenuBarItem.VirtualMachines.stop)
-                    }
+                    Text(L10n.MenuBarItem.VirtualMachines.stop)
                 }
-            }.disabled(isStoppingFleet)
+            }
         } else if hasSelectedVirtualMachine {
             Button {
                 onSelect(.start)

--- a/Packages/MenuBar/Sources/MenuBarItem/Internal/FleetMenuBarItem.swift
+++ b/Packages/MenuBar/Sources/MenuBarItem/Internal/FleetMenuBarItem.swift
@@ -1,42 +1,43 @@
 import SwiftUI
 
 struct FleetMenuBarItem: View {
+    enum Action {
+        case start
+        case stop
+    }
+
     let hasSelectedVirtualMachine: Bool
     let isFleetStarted: Bool
+    let isStoppingFleet: Bool
     let isEditorStarted: Bool
-    let startsSingleVirtualMachine: Bool
-    let onSelect: () -> Void
+    let onSelect: (Action) -> Void
 
     var body: some View {
         if isFleetStarted {
             Button {
-                onSelect()
+                onSelect(.stop)
             } label: {
                 HStack {
                     Image(systemName: "stop.fill")
-                    if startsSingleVirtualMachine {
-                        Text(L10n.MenuBarItem.VirtualMachines.Stop.singularis)
+                    if isStoppingFleet {
+                        Text(L10n.MenuBarItem.VirtualMachines.stopping)
                     } else {
-                        Text(L10n.MenuBarItem.VirtualMachines.Stop.pluralis)
+                        Text(L10n.MenuBarItem.VirtualMachines.stop)
                     }
                 }
-            }
+            }.disabled(isStoppingFleet)
         } else if hasSelectedVirtualMachine {
             Button {
-                onSelect()
+                onSelect(.start)
             } label: {
                 HStack {
                     Image(systemName: "play.fill")
-                    if startsSingleVirtualMachine {
-                        Text(L10n.MenuBarItem.VirtualMachines.Start.singularis)
-                    } else {
-                        Text(L10n.MenuBarItem.VirtualMachines.Start.pluralis)
-                    }
+                    Text(L10n.MenuBarItem.VirtualMachines.start)
                 }
             }.disabled(isEditorStarted)
         } else {
             Button {
-                onSelect()
+                onSelect(.start)
             } label: {
                 HStack {
                     Image(systemName: "desktopcomputer")

--- a/Packages/MenuBar/Sources/MenuBarItem/Internal/L10n.swift
+++ b/Packages/MenuBar/Sources/MenuBarItem/Internal/L10n.swift
@@ -36,20 +36,14 @@ internal enum L10n {
       }
     }
     internal enum VirtualMachines {
+      /// Start
+      internal static let start = L10n.tr("Localizable", "menu_bar_item.virtual_machines.start", fallback: "Start")
+      /// Stop
+      internal static let stop = L10n.tr("Localizable", "menu_bar_item.virtual_machines.stop", fallback: "Stop")
+      /// Stopping...
+      internal static let stopping = L10n.tr("Localizable", "menu_bar_item.virtual_machines.stopping", fallback: "Stopping...")
       /// Select Virtual Machine...
       internal static let unavailable = L10n.tr("Localizable", "menu_bar_item.virtual_machines.unavailable", fallback: "Select Virtual Machine...")
-      internal enum Start {
-        /// Start
-        internal static let pluralis = L10n.tr("Localizable", "menu_bar_item.virtual_machines.start.pluralis", fallback: "Start")
-        /// Start
-        internal static let singularis = L10n.tr("Localizable", "menu_bar_item.virtual_machines.start.singularis", fallback: "Start")
-      }
-      internal enum Stop {
-        /// Stop
-        internal static let pluralis = L10n.tr("Localizable", "menu_bar_item.virtual_machines.stop.pluralis", fallback: "Stop")
-        /// Stop
-        internal static let singularis = L10n.tr("Localizable", "menu_bar_item.virtual_machines.stop.singularis", fallback: "Stop")
-      }
     }
   }
 }

--- a/Packages/MenuBar/Sources/MenuBarItem/Internal/L10n.swift
+++ b/Packages/MenuBar/Sources/MenuBarItem/Internal/L10n.swift
@@ -42,6 +42,8 @@ internal enum L10n {
       internal static let stop = L10n.tr("Localizable", "menu_bar_item.virtual_machines.stop", fallback: "Stop")
       /// Stopping...
       internal static let stopping = L10n.tr("Localizable", "menu_bar_item.virtual_machines.stopping", fallback: "Stopping...")
+      /// Stops when virtual machines have terminated.
+      internal static let stoppingInfo = L10n.tr("Localizable", "menu_bar_item.virtual_machines.stopping_info", fallback: "Stops when virtual machines have terminated.")
       /// Select Virtual Machine...
       internal static let unavailable = L10n.tr("Localizable", "menu_bar_item.virtual_machines.unavailable", fallback: "Select Virtual Machine...")
     }

--- a/Packages/MenuBar/Sources/MenuBarItem/Internal/VirtualMachinesMenuContent.swift
+++ b/Packages/MenuBar/Sources/MenuBarItem/Internal/VirtualMachinesMenuContent.swift
@@ -1,23 +1,30 @@
-import SettingsStore
 import SwiftUI
 
 struct VirtualMachinesMenuContent: View {
     @StateObject private var viewModel: VirtualMachinesMenuContentViewModel
-    @ObservedObject private var settingsStore: SettingsStore
 
     init(viewModel: VirtualMachinesMenuContentViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
-        _settingsStore = ObservedObject(wrappedValue: viewModel.settingsStore)
     }
 
     var body: some View {
         FleetMenuBarItem(
             hasSelectedVirtualMachine: viewModel.hasSelectedVirtualMachine,
             isFleetStarted: viewModel.isFleetStarted,
-            isEditorStarted: viewModel.isEditorStarted,
-            startsSingleVirtualMachine: settingsStore.numberOfVirtualMachines == 1,
-            onSelect: viewModel.presentFleet
-        )
+            isStoppingFleet: viewModel.isStoppingFleet,
+            isEditorStarted: viewModel.isEditorStarted
+        ) { action in
+            switch action {
+            case .start:
+                if viewModel.hasSelectedVirtualMachine {
+                    viewModel.startFleet()
+                } else {
+                    viewModel.presentSettings()
+                }
+            case .stop:
+                viewModel.stopFleet()
+            }
+        }
         Divider()
         EditorMenuBarItem(
             isEditorStarted: viewModel.isEditorStarted,

--- a/Packages/MenuBar/Sources/MenuBarItem/Supporting files/Localizable.strings
+++ b/Packages/MenuBar/Sources/MenuBarItem/Supporting files/Localizable.strings
@@ -1,7 +1,6 @@
-"menu_bar_item.virtual_machines.start.singularis" = "Start";
-"menu_bar_item.virtual_machines.start.pluralis" = "Start";
-"menu_bar_item.virtual_machines.stop.singularis" = "Stop";
-"menu_bar_item.virtual_machines.stop.pluralis" = "Stop";
+"menu_bar_item.virtual_machines.start" = "Start";
+"menu_bar_item.virtual_machines.stop" = "Stop";
+"menu_bar_item.virtual_machines.stopping" = "Stopping...";
 "menu_bar_item.virtual_machines.unavailable" = "Select Virtual Machine...";
 "menu_bar_item.editor.edit_virtual_machine.start" = "Edit Virtual Machine";
 "menu_bar_item.editor.edit_virtual_machine.editing" = "Editing...";

--- a/Packages/MenuBar/Sources/MenuBarItem/Supporting files/Localizable.strings
+++ b/Packages/MenuBar/Sources/MenuBarItem/Supporting files/Localizable.strings
@@ -1,6 +1,7 @@
 "menu_bar_item.virtual_machines.start" = "Start";
 "menu_bar_item.virtual_machines.stop" = "Stop";
 "menu_bar_item.virtual_machines.stopping" = "Stopping...";
+"menu_bar_item.virtual_machines.stopping_info" = "Stops when virtual machines have terminated.";
 "menu_bar_item.virtual_machines.unavailable" = "Select Virtual Machine...";
 "menu_bar_item.editor.edit_virtual_machine.start" = "Edit Virtual Machine";
 "menu_bar_item.editor.edit_virtual_machine.editing" = "Editing...";

--- a/Packages/VirtualMachine/Sources/VirtualMachineFleet/VirtualMachineFleet.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineFleet/VirtualMachineFleet.swift
@@ -2,6 +2,8 @@ import Combine
 
 public protocol VirtualMachineFleet {
     var isStarted: AnyPublisher<Bool, Never> { get }
+    var isStopping: AnyPublisher<Bool, Never> { get }
     func start(numberOfMachines: Int) throws
+    func stopImmediately()
     func stop()
 }

--- a/Packages/VirtualMachine/Sources/VirtualMachineFleetLive/VirtualMachineFleetLive.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineFleetLive/VirtualMachineFleetLive.swift
@@ -11,8 +11,7 @@ public final class VirtualMachineFleetLive: VirtualMachineFleet {
 
     private let logger = Logger(category: "VirtualMachineFleetLive")
     private let virtualMachineFactory: VirtualMachineFactory
-    private var activeTasks: [Task<(), Never>] = []
-    private var activeMachineNames: Set<String> = []
+    private var activeTasks: [String: Task<(), Never>] = [:]
     private let _isStarted = CurrentValueSubject<Bool, Never>(false)
     private let _isStopping = CurrentValueSubject<Bool, Never>(false)
 
@@ -37,10 +36,10 @@ public final class VirtualMachineFleetLive: VirtualMachineFleet {
     public func stopImmediately() {
         _isStarted.value = false
         _isStopping.value = false
-        for task in activeTasks {
+        for (_, task) in activeTasks {
             task.cancel()
         }
-        activeTasks = []
+        activeTasks = [:]
     }
 
     public func stop() {
@@ -51,10 +50,12 @@ public final class VirtualMachineFleetLive: VirtualMachineFleet {
 private extension VirtualMachineFleetLive {
     private func startSequentiallyRunningVirtualMachines(named name: String) {
         let task = Task {
-            while !Task.isCancelled && !_isStopping.value {
+            while !Task.isCancelled {
                 do {
-                    activeMachineNames.insert(name)
                     try await runVirtualMachine(named: name)
+                    if _isStopping.value {
+                        activeTasks[name]?.cancel()
+                    }
                 } catch {
                     // Ignore the error and try again until the task is cancelled.
                     // The error should have been logged using OSLog so we know what is going on in case we need to debug.
@@ -63,12 +64,12 @@ private extension VirtualMachineFleetLive {
                 }
             }
             logger.info("Task running virtual machine named \(name, privacy: .public) was cancelled.")
-            activeMachineNames.remove(name)
-            if activeMachineNames.isEmpty {
+            activeTasks.removeValue(forKey: name)
+            if activeTasks.isEmpty {
                 stopImmediately()
             }
         }
-        activeTasks.append(task)
+        activeTasks[name] = task
     }
 
     private func runVirtualMachine(named name: String) async throws {


### PR DESCRIPTION
Selecting "Stop" to stop the virtual machines will no longer stop the virtual machines immediately. Instead, the fleet will no longer start new virtual machines when each virtual machine is shutdown.

This enables us to stop the fleet of virtual machines as soon as each virtual machine is shutdown.

<img width="246" alt="Screenshot 2023-09-21 at 17 16 26" src="https://github.com/shapehq/tartelet/assets/830995/3f9ee93d-d7d8-40f6-86c8-0178e68322ac">
<img width="415" alt="Screenshot 2023-09-21 at 17 22 27" src="https://github.com/shapehq/tartelet/assets/830995/52a05070-6ec2-4870-a2f0-fe5cff64548f">