### PR TITLE
Pre download the runner

### DIFF
--- a/Packages/GitHub/Sources/GitHubService/GitHubService.swift
+++ b/Packages/GitHub/Sources/GitHubService/GitHubService.swift
@@ -6,5 +6,11 @@ public protocol GitHubService {
       with appAccessToken: GitHubAppAccessToken,
       runnerScope: GitHubRunnerScope
     ) async throws -> GitHubRunnerRegistrationToken
-    func getRunnerDownloadURL(with appAccessToken: GitHubAppAccessToken, runnerScope: GitHubRunnerScope) async throws -> URL
+    func getRunnerDownloadURL(with appAccessToken: GitHubAppAccessToken, runnerScope: GitHubRunnerScope) async throws -> GitHubRunnerDownloadURL
+    func downloadRunner(_ url: GitHubRunnerDownloadURL) async throws -> Data
+}
+
+public protocol GitHubRunnerDownloadURL {
+    var downloadURL: URL { get }
+    var filename: String { get }
 }

--- a/Packages/GitHub/Sources/GitHubService/GitHubService.swift
+++ b/Packages/GitHub/Sources/GitHubService/GitHubService.swift
@@ -6,11 +6,9 @@ public protocol GitHubService {
       with appAccessToken: GitHubAppAccessToken,
       runnerScope: GitHubRunnerScope
     ) async throws -> GitHubRunnerRegistrationToken
-    func getRunnerDownloadURL(with appAccessToken: GitHubAppAccessToken, runnerScope: GitHubRunnerScope) async throws -> GitHubRunnerDownloadURL
-    func downloadRunner(_ url: GitHubRunnerDownloadURL) async throws -> Data
-}
-
-public protocol GitHubRunnerDownloadURL {
-    var downloadURL: URL { get }
-    var filename: String { get }
+    func downloadRunner(
+        with appAccessToken: GitHubAppAccessToken,
+        runnerScope: GitHubRunnerScope,
+        toDirectory cacheDirectoryURL: URL
+    ) async throws -> URL
 }

--- a/Packages/GitHub/Sources/GitHubServiceLive/Internal/GitHubRunnerDownload.swift
+++ b/Packages/GitHub/Sources/GitHubServiceLive/Internal/GitHubRunnerDownload.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GitHubService
 
-public struct GitHubRunnerDownload: Codable, GitHubRunnerDownloadURL {
+public struct GitHubRunnerDownload: Codable {
     private enum CodingKeys: String, CodingKey {
         case os
         case architecture

--- a/Packages/GitHub/Sources/GitHubServiceLive/Internal/GitHubRunnerDownload.swift
+++ b/Packages/GitHub/Sources/GitHubServiceLive/Internal/GitHubRunnerDownload.swift
@@ -1,13 +1,16 @@
 import Foundation
+import GitHubService
 
-public struct GitHubRunnerDownload: Codable {
+public struct GitHubRunnerDownload: Codable, GitHubRunnerDownloadURL {
     private enum CodingKeys: String, CodingKey {
         case os
         case architecture
         case downloadURL = "download_url"
+        case filename
     }
 
     let os: String
     let architecture: String
-    let downloadURL: URL
+    public let downloadURL: URL
+    public let filename: String
 }

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesCopier/VirtualMachineResourcesCopier.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesCopier/VirtualMachineResourcesCopier.swift
@@ -15,22 +15,26 @@ public struct VirtualMachineResourcesCopier {
         let sourceFileURLs = try fileSystem.contentsOfDirectory(at: sourceDirectoryURL)
         for sourceFileURL in sourceFileURLs {
             let destinationFileURL = destinationDirectoryURL.appending(path: sourceFileURL.lastPathComponent)
-            do {
-                if fileSystem.itemExists(at: destinationFileURL) {
-                    try fileSystem.removeItem(at: destinationFileURL)
-                }
-            } catch {
-                // Log the error but don't rethrow it as it is not severe.
-                // swiftlint:disable:next line_length
-                logger.info("Failed removing resources at \(destinationFileURL.absoluteString, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            try copySingleResource(from: sourceFileURL, to: destinationFileURL)
+        }
+    }
+
+    public func copySingleResource(from sourceFileURL: URL, to destinationFileURL: URL) throws {
+        do {
+            if fileSystem.itemExists(at: destinationFileURL) {
+                try fileSystem.removeItem(at: destinationFileURL)
             }
-            do {
-                try fileSystem.copyItem(from: sourceFileURL, to: destinationFileURL)
-            } catch {
-                // swiftlint:disable:next line_length
-                logger.info("Failed copying resources from \(sourceFileURL.absoluteString, privacy: .public) to \(destinationFileURL.absoluteString, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                throw error
-            }
+        } catch {
+            // Log the error but don't rethrow it as it is not severe.
+            // swiftlint:disable:next line_length
+            logger.info("Failed removing resources at \(destinationFileURL.absoluteString, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+        do {
+            try fileSystem.copyItem(from: sourceFileURL, to: destinationFileURL)
+        } catch {
+            // swiftlint:disable:next line_length
+            logger.info("Failed copying resources from \(sourceFileURL.absoluteString, privacy: .public) to \(destinationFileURL.absoluteString, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            throw error
         }
     }
 }

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
@@ -41,6 +41,10 @@ if [ ! -f $RUNNER_GROUP_FILE ]; then
   echo "The RUNNER_GROUP file was not found"
   exit 1
 fi
+if [ ! -f $ACTIONS_RUNNER_ARCHIVE ]; then
+  echo "The ACTIONS_RUNNER_ARCHIVE file was not found"
+  exit 1
+fi
 
 # Read constants from files
 RUNNER_NAME=$(<./RUNNER_NAME)
@@ -48,12 +52,6 @@ RUNNER_URL=$(<./RUNNER_URL)
 RUNNER_TOKEN=$(<./RUNNER_TOKEN)
 RUNNER_LABELS=$(<./RUNNER_LABELS)
 RUNNER_GROUP=$(<./RUNNER_GROUP)
-
-# Download the runner if the archive does not already exist
-if [ ! -f $ACTIONS_RUNNER_ARCHIVE ]; then
-  echo "The ACTIONS_RUNNER_ARCHIVE file was not found"
-  exit 1
-fi
 
 # Unarchive the runner
 mkdir $ACTIONS_RUNNER_DIRECTORY

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
@@ -7,7 +7,6 @@ WORK_DIRECTORY=_work
 RUNNER_NAME_FILE=./RUNNER_NAME
 RUNNER_URL_FILE=./RUNNER_URL
 RUNNER_TOKEN_FILE=./RUNNER_TOKEN
-RUNNER_DOWNLOAD_URL_FILE=./RUNNER_DOWNLOAD_URL
 RUNNER_LABELS_FILE=./RUNNER_LABELS
 RUNNER_GROUP_FILE=./RUNNER_GROUP
 
@@ -34,10 +33,6 @@ if [ ! -f $RUNNER_TOKEN_FILE ]; then
   echo "The RUNNER_TOKEN file was not found"
   exit 1
 fi
-if [ ! -f $RUNNER_DOWNLOAD_URL_FILE ]; then
-  echo "The RUNNER_DOWNLOAD_URL file was not found"
-  exit 1
-fi
 if [ ! -f $RUNNER_LABELS_FILE ]; then
   echo "The RUNNER_LABELS file was not found"
   exit 1
@@ -51,13 +46,13 @@ fi
 RUNNER_NAME=$(<./RUNNER_NAME)
 RUNNER_URL=$(<./RUNNER_URL)
 RUNNER_TOKEN=$(<./RUNNER_TOKEN)
-RUNNER_DOWNLOAD_URL=$(<./RUNNER_DOWNLOAD_URL)
 RUNNER_LABELS=$(<./RUNNER_LABELS)
 RUNNER_GROUP=$(<./RUNNER_GROUP)
 
 # Download the runner if the archive does not already exist
 if [ ! -f $ACTIONS_RUNNER_ARCHIVE ]; then
-  curl -o $ACTIONS_RUNNER_ARCHIVE -L $RUNNER_DOWNLOAD_URL
+  echo "The ACTIONS_RUNNER_ARCHIVE file was not found"
+  exit 1
 fi
 
 # Unarchive the runner

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
@@ -91,11 +91,7 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         try fileSystem.createDirectoryIfNeeded(at: directoryURL)
         if fileSystem.itemExists(at: directoryURL) {
             try resourcesCopier.copyResources(from: editorResourcesDirectoryURL, to: directoryURL)
-            let runnerApplicationFileURL = directoryURL.appending(path: ResourceFilename.runnerApplication)
-            if fileSystem.itemExists(at: runnerApplicationFileURL) {
-                try fileSystem.removeItem(at: runnerApplicationFileURL)
-            }
-            try fileSystem.copyItem(from: runnerCacheFileURL, to: runnerApplicationFileURL)
+            try resourcesCopier.copySingleResource(from: runnerCacheFileURL, to: directoryURL.appending(path: ResourceFilename.runnerApplication))
         }
         let runnerNameFileURL = directoryURL.appending(path: ResourceFilename.runnerName)
         let runnerURLFileURL = directoryURL.appending(path: ResourceFilename.runnerURL)

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
@@ -27,7 +27,6 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         static let runnerLabels = "RUNNER_LABELS"
         static let runnerGroup = "RUNNER_GROUP"
         static let runnerApplication = "actions-runner.tar.gz"
-        static let runnerVersion = "RUNNER_VERSION"
     }
 
     public var directoryURL: URL {

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
@@ -78,15 +78,11 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         let runnerURL = try await getRunnerURL()
         let appAccessToken = try await gitHubService.getAppAccessToken(runnerScope: runnerScope)
         let runnerToken = try await gitHubService.getRunnerRegistrationToken(with: appAccessToken, runnerScope: runnerScope)
-        let runnerDownloadURL = try await gitHubService.getRunnerDownloadURL(with: appAccessToken, runnerScope: runnerScope)
-
-        let runnerCacheFileURL = runnerCacheDirectoryURL.appending(path: runnerDownloadURL.filename)
-        if !fileSystem.itemExists(at: runnerCacheFileURL) {
-            try? fileSystem.removeItem(at: runnerCacheDirectoryURL)
-            try fileSystem.createDirectoryIfNeeded(at: runnerCacheDirectoryURL)
-            let runnerApplication = try await gitHubService.downloadRunner(runnerDownloadURL)
-            try runnerApplication.write(to: runnerCacheFileURL)
-        }
+        let runnerCacheFileURL = try await gitHubService.downloadRunner(
+            with: appAccessToken,
+            runnerScope: runnerScope,
+            toDirectory: runnerCacheDirectoryURL
+        )
 
         try fileSystem.createDirectoryIfNeeded(at: directoryURL)
         if fileSystem.itemExists(at: directoryURL) {

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
@@ -26,8 +26,8 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         static let runnerToken = "RUNNER_TOKEN"
         static let runnerLabels = "RUNNER_LABELS"
         static let runnerGroup = "RUNNER_GROUP"
-		static let runnerApplication = "actions-runner.tar.gz"
-		static let runnerVersion = "RUNNER_VERSION"
+        static let runnerApplication = "actions-runner.tar.gz"
+        static let runnerVersion = "RUNNER_VERSION"
     }
 
     public var directoryURL: URL {

--- a/Tartelet/Sources/CompositionRoot.swift
+++ b/Tartelet/Sources/CompositionRoot.swift
@@ -127,7 +127,8 @@ private extension CompositionRoot {
     private static var gitHubService: GitHubService {
         GitHubServiceLive(
             credentialsStore: gitHubCredentialsStore,
-            networkingService: networkingService
+            networkingService: networkingService,
+            fileSystem: fileSystem
         )
     }
 


### PR DESCRIPTION
I already had copied the runner tar into the resources folder so that it would skip downloading the runner each time, but then when a new version had been released, the runner would update itself, so I would keep copying it manually whenever I noticed a new version to save the download time on each job.

It only saves about 10 seconds, (my office internet isn't the fastest) but it seems worth it, I have a lint CI job that takes 20 seconds so 10 seconds is a noticeable difference.

I'm not sure if this is best the way to code it. the 4th commit (https://github.com/shapehq/tartelet/pull/52/commits/dadd5e33db6ff9002cda5d8db9755d19c89a0c65)  is optional in that it's a refactor, so if you prefer the GithubService not to do file system operations it can be reverted. Or any other feedback would be good :)

