### PR TITLE
Enterprise hosting support

### DIFF
--- a/Packages/GitHub/Sources/GitHubCredentialsStore/GitHubCredentialsStore.swift
+++ b/Packages/GitHub/Sources/GitHubCredentialsStore/GitHubCredentialsStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public protocol GitHubCredentialsStore: AnyObject {
+    var selfHostedURL: URL? { get async }
     var organizationName: String? { get async }
     var repositoryName: String? { get async }
     var ownerName: String? { get async }

--- a/Packages/GitHub/Sources/GitHubCredentialsStore/GitHubCredentialsStore.swift
+++ b/Packages/GitHub/Sources/GitHubCredentialsStore/GitHubCredentialsStore.swift
@@ -7,6 +7,7 @@ public protocol GitHubCredentialsStore: AnyObject {
     var ownerName: String? { get async }
     var appId: String? { get async }
     var privateKey: Data? { get async }
+    func setSelfHostedURL(_ selfHostedURL: URL?) async
     func setOrganizationName(_ organizationName: String?) async
     func setRepository(_ repositoryName: String?, withOwner ownerName: String?) async
     func setAppID(_ appID: String?) async

--- a/Packages/GitHub/Sources/GitHubCredentialsStore/GitHubCredentialsStore.swift
+++ b/Packages/GitHub/Sources/GitHubCredentialsStore/GitHubCredentialsStore.swift
@@ -5,11 +5,13 @@ public protocol GitHubCredentialsStore: AnyObject {
     var organizationName: String? { get async }
     var repositoryName: String? { get async }
     var ownerName: String? { get async }
+    var enterpriseName: String? { get async }
     var appId: String? { get async }
     var privateKey: Data? { get async }
     func setSelfHostedURL(_ selfHostedURL: URL?) async
     func setOrganizationName(_ organizationName: String?) async
     func setRepository(_ repositoryName: String?, withOwner ownerName: String?) async
+    func setEnterpriseName(_ enterpriseName: String?) async
     func setAppID(_ appID: String?) async
     func setPrivateKey(_ privateKeyData: Data?) async
 }

--- a/Packages/GitHub/Sources/GitHubCredentialsStoreKeychain/GitHubCredentialsStoreKeychain.swift
+++ b/Packages/GitHub/Sources/GitHubCredentialsStoreKeychain/GitHubCredentialsStoreKeychain.swift
@@ -5,6 +5,7 @@ import RSAPrivateKey
 
 public final actor GitHubCredentialsStoreKeychain: GitHubCredentialsStore {
     private enum PasswordAccount {
+        static let selfHostedURL = "github.credentials.selfHostedURL"
         static let organizationName = "github.credentials.organizationName"
         static let repositoryName = "github.credentials.repositoryName"
         static let ownerName = "github.credentials.ownerName"
@@ -15,6 +16,12 @@ public final actor GitHubCredentialsStoreKeychain: GitHubCredentialsStore {
         static let privateKey = "github.credentials.privateKey"
     }
 
+    public var selfHostedURL: URL? {
+        get async {
+            return await keychain.password(forAccount: PasswordAccount.selfHostedURL, belongingToService: serviceName)
+                .flatMap(URL.init(string:))
+        }
+    }
     public var organizationName: String? {
         get async {
             return await keychain.password(forAccount: PasswordAccount.organizationName, belongingToService: serviceName)
@@ -47,6 +54,14 @@ public final actor GitHubCredentialsStoreKeychain: GitHubCredentialsStore {
     public init(keychain: Keychain, serviceName: String) {
         self.keychain = keychain
         self.serviceName = serviceName
+    }
+
+    public func setSelfHostedURL(_ selfHostedURL: URL?) async {
+        if let selfHostedURL {
+            _ = await keychain.setPassword(selfHostedURL.absoluteString, forAccount: PasswordAccount.selfHostedURL, belongingToService: serviceName)
+        } else {
+            await keychain.removePassword(forAccount: PasswordAccount.selfHostedURL, belongingToService: serviceName)
+        }
     }
 
     public func setOrganizationName(_ organizationName: String?) async {

--- a/Packages/GitHub/Sources/GitHubCredentialsStoreKeychain/GitHubCredentialsStoreKeychain.swift
+++ b/Packages/GitHub/Sources/GitHubCredentialsStoreKeychain/GitHubCredentialsStoreKeychain.swift
@@ -9,6 +9,7 @@ public final actor GitHubCredentialsStoreKeychain: GitHubCredentialsStore {
         static let organizationName = "github.credentials.organizationName"
         static let repositoryName = "github.credentials.repositoryName"
         static let ownerName = "github.credentials.ownerName"
+        static let enterpriseName = "github.credentials.enterpriseName"
         static let appId = "github.credentials.appId"
     }
 
@@ -35,6 +36,11 @@ public final actor GitHubCredentialsStoreKeychain: GitHubCredentialsStore {
     public var ownerName: String? {
         get async {
             return await keychain.password(forAccount: PasswordAccount.ownerName, belongingToService: serviceName)
+        }
+    }
+    public var enterpriseName: String? {
+        get async {
+            return await keychain.password(forAccount: PasswordAccount.enterpriseName, belongingToService: serviceName)
         }
     }
     public var appId: String? {
@@ -81,6 +87,14 @@ public final actor GitHubCredentialsStoreKeychain: GitHubCredentialsStore {
             _ = await keychain.setPassword(ownerName, forAccount: PasswordAccount.ownerName, belongingToService: serviceName)
         } else {
             await keychain.removePassword(forAccount: PasswordAccount.ownerName, belongingToService: serviceName)
+        }
+    }
+
+    public func setEnterpriseName(_ enterpriseName: String?) async {
+        if let enterpriseName {
+            _ = await keychain.setPassword(enterpriseName, forAccount: PasswordAccount.enterpriseName, belongingToService: serviceName)
+        } else {
+            await keychain.removePassword(forAccount: PasswordAccount.enterpriseName, belongingToService: serviceName)
         }
     }
 

--- a/Packages/GitHub/Sources/GitHubService/GitHubRunnerScope.swift
+++ b/Packages/GitHub/Sources/GitHubService/GitHubRunnerScope.swift
@@ -3,4 +3,5 @@ import Foundation
 public enum GitHubRunnerScope: String, CaseIterable {
   case organization
   case repo
+  case enterpriseServer
 }

--- a/Packages/GitHub/Sources/GitHubService/GitHubServiceVersion.swift
+++ b/Packages/GitHub/Sources/GitHubService/GitHubServiceVersion.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public enum GitHubServiceVersion {
+  case dotCom
+  case enterprise(URL)
+
+  public enum Kind: String, CaseIterable {
+    case dotCom
+    case enterprise
+  }
+}

--- a/Packages/GitHub/Sources/GitHubServiceLive/GitHubServiceLive.swift
+++ b/Packages/GitHub/Sources/GitHubServiceLive/GitHubServiceLive.swift
@@ -8,6 +8,7 @@ private enum GitHubServiceLiveError: LocalizedError {
     case organizationNameUnavailable
     case repositoryNameUnavailable
     case repositoryOwnerNameUnavailable
+    case enterpriseNameUnavailable
     case appIDUnavailable
     case privateKeyUnavailable
     case appIsNotInstalled
@@ -21,6 +22,8 @@ private enum GitHubServiceLiveError: LocalizedError {
             return "The repository name is not available"
         case .repositoryOwnerNameUnavailable:
             return "The repository owner name is not available"
+        case .enterpriseNameUnavailable:
+            return "The enterprise name is not available"
         case .appIDUnavailable:
             return "The app ID is not available"
         case .privateKeyUnavailable:
@@ -141,6 +144,11 @@ private extension GitHubRunnerScope {
             }
 
             return "/repos/\(ownerName)/\(repositoryName)/actions/runners/registration-token"
+        case .enterpriseServer:
+          guard let enterpriseName = await credentialsStore.enterpriseName else {
+              throw GitHubServiceLiveError.enterpriseNameUnavailable
+          }
+          return "/enterprises/\(enterpriseName)/actions/runners/registration-token"
         }
     }
 
@@ -160,6 +168,11 @@ private extension GitHubRunnerScope {
             }
 
             return "/repos/\(ownerName)/\(repositoryName)/actions/runners/downloads"
+        case .enterpriseServer:
+            guard let enterpriseName = await credentialsStore.enterpriseName else {
+                throw GitHubServiceLiveError.enterpriseNameUnavailable
+            }
+            return "/enterprises/\(enterpriseName)/actions/runners/downloads"
         }
     }
 
@@ -169,6 +182,8 @@ private extension GitHubRunnerScope {
         return await credentialsStore.organizationName
       case .repo:
         return await credentialsStore.ownerName
+      case .enterpriseServer:
+          return await credentialsStore.enterpriseName
       }
     }
 }

--- a/Packages/Settings/Sources/SettingsStore/SettingsStore.swift
+++ b/Packages/Settings/Sources/SettingsStore/SettingsStore.swift
@@ -14,6 +14,7 @@ public final class SettingsStore: ObservableObject {
         static let gitHubRunnerLabels = "gitHubRunnerLabels"
         static let gitHubRunnerGroup = "gitHubRunnerGroup"
         static let githubRunnerScope = "githubRunnerScope"
+        static let githubServiceVersion = "githubServiceVersion"
     }
 
     @AppStorage(AppStorageKey.applicationUIMode)
@@ -34,6 +35,8 @@ public final class SettingsStore: ObservableObject {
     public var gitHubRunnerGroup = ""
     @AppStorage(AppStorageKey.githubRunnerScope)
     public var githubRunnerScope: GitHubRunnerScope = .organization
+    @AppStorage(AppStorageKey.githubServiceVersion)
+    public var githubServiceVersion: GitHubServiceVersion.Kind = .dotCom
 
     public init() {}
 

--- a/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubPrivateKeyPicker.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubPrivateKeyPicker.swift
@@ -12,6 +12,8 @@ struct GitHubPrivateKeyPicker: View {
             L10n.Settings.Github.PrivateKey.Scopes.organization
         case .repo:
             L10n.Settings.Github.PrivateKey.Scopes.repository
+        case .enterpriseServer:
+            "Check permissions: `manage_runners:enterprise`"
         }
     }
 

--- a/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubSettingsView.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubSettingsView.swift
@@ -14,6 +14,21 @@ struct GitHubSettingsView: View {
     var body: some View {
         Form {
             Section {
+                Picker("Version", selection: $viewModel.version) {
+                    ForEach(GitHubServiceVersion.Kind.allCases, id: \.self) { scope in
+                        Text(scope.title)
+                    }
+                }
+
+                if viewModel.version == .enterprise {
+                    TextField(
+                        "Self hosted URL",
+                        text: $viewModel.selfHostedRaw,
+                        prompt: Text("Github Service raw value")
+                    )
+                    .disabled(!viewModel.isSettingsEnabled)
+                }
+
                 Picker(L10n.Settings.Github.runnerScope, selection: $viewModel.runnerScope) {
                     ForEach(GitHubRunnerScope.allCases, id: \.self) { scope in
                         Text(scope.title)
@@ -77,6 +92,17 @@ private extension GitHubRunnerScope {
             L10n.Settings.RunnerScope.organization
         case .repo:
             L10n.Settings.RunnerScope.repository
+        }
+    }
+}
+
+private extension GitHubServiceVersion.Kind {
+    var title: String {
+        switch self {
+        case .dotCom:
+            return "github.com"
+        case .enterprise:
+            return "github self hosted"
         }
     }
 }

--- a/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubSettingsView.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/GitHubSettings/GitHubSettingsView.swift
@@ -56,6 +56,13 @@ struct GitHubSettingsView: View {
                         prompt: Text(L10n.Settings.Github.RepositoryName.prompt)
                     )
                     .disabled(!viewModel.isSettingsEnabled)
+                case .enterpriseServer:
+                    TextField(
+                        "Enterprise name",
+                        text: $viewModel.enterpriseName,
+                        prompt: Text("Acme Enterprise")
+                    )
+                    .disabled(!viewModel.isSettingsEnabled)
                 }
             }
             Section {
@@ -92,6 +99,8 @@ private extension GitHubRunnerScope {
             L10n.Settings.RunnerScope.organization
         case .repo:
             L10n.Settings.RunnerScope.repository
+        case .enterpriseServer:
+            "Enterprise"
         }
     }
 }


### PR DESCRIPTION
Add the ability to specify an GitHub Enterprise Server URL so that users can use custom instances of self-hosted GitHub. The runner type `enterprise` is added so enterprises hosted on GitHub Cloud can add runners to the whole enterprise

Fixes #27 