### PR TITLE
Use built in tart caching to pre download the runner

### DIFF
--- a/Packages/Tart/Sources/Tart/Tart+Directory.swift
+++ b/Packages/Tart/Sources/Tart/Tart+Directory.swift
@@ -3,11 +3,19 @@ import Foundation
 public extension Tart {
     struct Directory {
         public let name: String
-        public let directoryURL: URL
+        private let url: URL
 
-        public init(name: String, directoryURL: URL) {
+        public init(name: String, url: URL) {
             self.name = name
-            self.directoryURL = directoryURL
+            self.url = url
+        }
+
+        public var pathOrURL: String {
+            if url.isFileURL {
+                url.path
+            } else {
+                url.absoluteString
+            }
         }
     }
 }

--- a/Packages/Tart/Sources/Tart/Tart.swift
+++ b/Packages/Tart/Sources/Tart/Tart.swift
@@ -1,13 +1,16 @@
+import Foundation
 import Shell
 
 public struct Tart {
     private let homeProvider: TartHomeProvider
     private let shell: Shell
     private var environment: [String: String]? {
-        guard let homeFolderURL = homeProvider.homeFolderURL else {
-            return nil
+        var env = [String: String]()
+        env["PATH"] = ProcessInfo.processInfo.environment["PATH"]
+        if let homeFolderURL = homeProvider.homeFolderURL {
+            env["TART_HOME"] = homeFolderURL.absoluteString
         }
-        return ["TART_HOME": homeFolderURL.absoluteString]
+        return env
     }
 
     public init(homeProvider: TartHomeProvider, shell: Shell) {
@@ -20,7 +23,7 @@ public struct Tart {
     }
 
     public func run(name: String, mounting directories: [Directory] = []) async throws {
-        let mountArgs = directories.map { "--dir=\($0.name):\($0.directoryURL.path)" }
+        let mountArgs = directories.map { "--dir=\($0.name):\($0.pathOrURL)" }
         let args = ["run"] + mountArgs + [name]
         try await executeCommand(withArguments: args)
     }

--- a/Packages/TartVirtualMachine/Sources/EphemeralTartVirtualMachine/EphemeralTartVirtualMachine.swift
+++ b/Packages/TartVirtualMachine/Sources/EphemeralTartVirtualMachine/EphemeralTartVirtualMachine.swift
@@ -47,7 +47,7 @@ public final class EphemeralTartVirtualMachine: VirtualMachine {
         logger.info("Clone Tart image named \(sourceVMName, privacy: .public) to \(destinationVMName, privacy: .public)...")
         try await tart.clone(sourceName: sourceVMName, newName: destinationVMName)
         logger.info("Run Tart image named \(destinationVMName, privacy: .public)...")
-        try await tart.run(name: destinationVMName, mounting: [.resources(at: resourcesDirectoryURL), .init(name: "ghar", directoryURL: runnerApplicationURL)])
+        try await tart.run(name: destinationVMName, mounting: [.resources(at: resourcesDirectoryURL), .init(name: "ghar", url: runnerApplicationURL)])
         logger.info("Delete Tart image named \(destinationVMName, privacy: .public)...")
         try await tart.delete(name: destinationVMName)
         onCleanup()

--- a/Packages/TartVirtualMachine/Sources/EphemeralTartVirtualMachine/EphemeralTartVirtualMachine.swift
+++ b/Packages/TartVirtualMachine/Sources/EphemeralTartVirtualMachine/EphemeralTartVirtualMachine.swift
@@ -17,6 +17,7 @@ public final class EphemeralTartVirtualMachine: VirtualMachine {
     private let sourceVMName: String
     private let destinationVMName: String
     private let resourcesDirectoryURL: URL
+    private let runnerApplicationURL: URL
     private let onCleanup: CleanupHandler
     private var runTask: Task<(), Error>?
     private let logger = Logger(category: "EphemeralTartVirtualMachine")
@@ -26,12 +27,14 @@ public final class EphemeralTartVirtualMachine: VirtualMachine {
         sourceVMName: String,
         destinationVMName: String,
         resourcesDirectoryURL: URL,
+        runnerApplicationURL: URL,
         onCleanup: @escaping CleanupHandler
     ) {
         self.tart = tart
         self.sourceVMName = sourceVMName
         self.destinationVMName = destinationVMName
         self.resourcesDirectoryURL = resourcesDirectoryURL
+        self.runnerApplicationURL = runnerApplicationURL
         self.onCleanup = onCleanup
     }
 
@@ -44,7 +47,7 @@ public final class EphemeralTartVirtualMachine: VirtualMachine {
         logger.info("Clone Tart image named \(sourceVMName, privacy: .public) to \(destinationVMName, privacy: .public)...")
         try await tart.clone(sourceName: sourceVMName, newName: destinationVMName)
         logger.info("Run Tart image named \(destinationVMName, privacy: .public)...")
-        try await tart.run(name: destinationVMName, mounting: [.resources(at: resourcesDirectoryURL)])
+        try await tart.run(name: destinationVMName, mounting: [.resources(at: resourcesDirectoryURL), .init(name: "ghar", directoryURL: runnerApplicationURL)])
         logger.info("Delete Tart image named \(destinationVMName, privacy: .public)...")
         try await tart.delete(name: destinationVMName)
         onCleanup()

--- a/Packages/TartVirtualMachine/Sources/TartDirectoryHelpers/TartDirectory+Helpers.swift
+++ b/Packages/TartVirtualMachine/Sources/TartDirectoryHelpers/TartDirectory+Helpers.swift
@@ -3,6 +3,6 @@ import Tart
 
 public extension Tart.Directory {
     static func resources(at directoryURL: URL) -> Tart.Directory {
-        return Self(name: "Resources", directoryURL: directoryURL)
+        return Self(name: "Resources", url: directoryURL)
     }
 }

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
@@ -59,7 +59,7 @@ if [ -f $POST_RUN_SCRIPT ]; then
 fi
 
 # Configure and run the runner
-cd $ACTIONS_RUNNER_DIRECTORY
+cd "$ACTIONS_RUNNER_DIRECTORY"
 ./config.sh \
   --url "${RUNNER_URL}" \
   --unattended \

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
@@ -1,13 +1,11 @@
 #!/bin/zsh
 PRE_RUN_SCRIPT="pre-run.sh"
 POST_RUN_SCRIPT="post-run.sh"
-ACTIONS_RUNNER_ARCHIVE=./actions-runner.tar.gz
-ACTIONS_RUNNER_DIRECTORY=~/actions-runner
+ACTIONS_RUNNER_DIRECTORY="/Volumes/My Shared Files/ghar"
 WORK_DIRECTORY=_work
 RUNNER_NAME_FILE=./RUNNER_NAME
 RUNNER_URL_FILE=./RUNNER_URL
 RUNNER_TOKEN_FILE=./RUNNER_TOKEN
-RUNNER_DOWNLOAD_URL_FILE=./RUNNER_DOWNLOAD_URL
 RUNNER_LABELS_FILE=./RUNNER_LABELS
 RUNNER_GROUP_FILE=./RUNNER_GROUP
 
@@ -18,7 +16,7 @@ function onexit {
 }
 trap onexit EXIT
 
-# Run the script from the Resources folder
+# Read the values from the Resources folder
 cd "/Volumes/My Shared Files/Resources"
 
 # Check if files with constants exist
@@ -34,10 +32,6 @@ if [ ! -f $RUNNER_TOKEN_FILE ]; then
   echo "The RUNNER_TOKEN file was not found"
   exit 1
 fi
-if [ ! -f $RUNNER_DOWNLOAD_URL_FILE ]; then
-  echo "The RUNNER_DOWNLOAD_URL file was not found"
-  exit 1
-fi
 if [ ! -f $RUNNER_LABELS_FILE ]; then
   echo "The RUNNER_LABELS file was not found"
   exit 1
@@ -51,18 +45,8 @@ fi
 RUNNER_NAME=$(<./RUNNER_NAME)
 RUNNER_URL=$(<./RUNNER_URL)
 RUNNER_TOKEN=$(<./RUNNER_TOKEN)
-RUNNER_DOWNLOAD_URL=$(<./RUNNER_DOWNLOAD_URL)
 RUNNER_LABELS=$(<./RUNNER_LABELS)
 RUNNER_GROUP=$(<./RUNNER_GROUP)
-
-# Download the runner if the archive does not already exist
-if [ ! -f $ACTIONS_RUNNER_ARCHIVE ]; then
-  curl -o $ACTIONS_RUNNER_ARCHIVE -L $RUNNER_DOWNLOAD_URL
-fi
-
-# Unarchive the runner
-mkdir $ACTIONS_RUNNER_DIRECTORY
-tar xzf $ACTIONS_RUNNER_ARCHIVE --directory $ACTIONS_RUNNER_DIRECTORY
 
 # Setup the pre- and post-job scripts if needed
 if [ -f $PRE_RUN_SCRIPT ]; then

--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/VirtualMachineResourcesServiceEphemeral.swift
@@ -24,7 +24,6 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         static let runnerName = "RUNNER_NAME"
         static let runnerURL = "RUNNER_URL"
         static let runnerToken = "RUNNER_TOKEN"
-        static let runnerDownloadURL = "RUNNER_DOWNLOAD_URL"
         static let runnerLabels = "RUNNER_LABELS"
         static let runnerGroup = "RUNNER_GROUP"
     }
@@ -71,7 +70,6 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         let runnerURL = try await getRunnerURL()
         let appAccessToken = try await gitHubService.getAppAccessToken(runnerScope: runnerScope)
         let runnerToken = try await gitHubService.getRunnerRegistrationToken(with: appAccessToken, runnerScope: runnerScope)
-        let runnerDownloadURL = try await gitHubService.getRunnerDownloadURL(with: appAccessToken, runnerScope: runnerScope)
         try fileSystem.createDirectoryIfNeeded(at: directoryURL)
         if fileSystem.itemExists(at: directoryURL) {
             try resourcesCopier.copyResources(from: editorResourcesDirectoryURL, to: directoryURL)
@@ -79,13 +77,11 @@ public struct VirtualMachineResourcesServiceEphemeral: VirtualMachineResourcesSe
         let runnerNameFileURL = directoryURL.appending(path: ResourceFilename.runnerName)
         let runnerURLFileURL = directoryURL.appending(path: ResourceFilename.runnerURL)
         let runnerTokenFileURL = directoryURL.appending(path: ResourceFilename.runnerToken)
-        let runnerDownloadURLFileURL = directoryURL.appending(path: ResourceFilename.runnerDownloadURL)
         let runnerLabelsFileURL = directoryURL.appending(path: ResourceFilename.runnerLabels)
         let runnerGroupFileURL = directoryURL.appending(path: ResourceFilename.runnerGroup)
         try virtualMachineName.write(to: runnerNameFileURL, atomically: true, encoding: .utf8)
         try runnerURL.absoluteString.write(to: runnerURLFileURL, atomically: true, encoding: .utf8)
         try runnerToken.rawValue.write(to: runnerTokenFileURL, atomically: true, encoding: .utf8)
-        try runnerDownloadURL.absoluteString.write(to: runnerDownloadURLFileURL, atomically: true, encoding: .utf8)
         try runnerLabels.write(to: runnerLabelsFileURL, atomically: true, encoding: .utf8)
         try runnerGroup.write(to: runnerGroupFileURL, atomically: true, encoding: .utf8)
         if let resourcesDirectoryURL = Bundle.module.resourceURL?.appending(path: "Resources") {

--- a/Tartelet/Sources/Composition/EphemeralVirtualMachineFactory.swift
+++ b/Tartelet/Sources/Composition/EphemeralVirtualMachineFactory.swift
@@ -1,5 +1,7 @@
 import EphemeralTartVirtualMachine
 import Foundation
+import GitHubCredentialsStore
+import GitHubService
 import LogHelpers
 import OSLog
 import SettingsStore
@@ -7,8 +9,6 @@ import Tart
 import VirtualMachine
 import VirtualMachineFactory
 import VirtualMachineResourcesService
-import GitHubService
-import GitHubCredentialsStore
 
 enum EphemeralVirtualMachineFactoryError: LocalizedError {
     case sourceVirtualMachineNameUnavailable
@@ -27,7 +27,7 @@ struct EphemeralVirtualMachineFactory: VirtualMachineFactory {
     let resourcesServiceFactory: VirtualMachineResourcesServiceFactory
     let gitHubService: GitHubService
     let gitHubCredentialsStore: GitHubCredentialsStore
-    
+
     var preferredVirtualMachineName: String {
         get throws {
             guard case let .virtualMachine(vmName) = settingsStore.virtualMachine else {

--- a/Tartelet/Sources/CompositionRoot.swift
+++ b/Tartelet/Sources/CompositionRoot.swift
@@ -95,7 +95,9 @@ private extension CompositionRoot {
         EphemeralVirtualMachineFactory(
             tart: tart,
             settingsStore: settingsStore,
-            resourcesServiceFactory: ephemeralVirtualMachineResourcesServiceFactory
+            resourcesServiceFactory: ephemeralVirtualMachineResourcesServiceFactory,
+            gitHubService: gitHubService,
+            gitHubCredentialsStore: gitHubCredentialsStore
         )
     }
 


### PR DESCRIPTION
remake of this PR: #52
requires tart 2.1.0

I already had copied the runner tar into the resources folder so that it would skip downloading the runner each time, but then when a new version had been released, the runner would update itself, so I would keep copying it manually whenever I noticed a new version to save the download time on each job.

It only saves about 10 seconds, (my office internet isn't the fastest) but it seems worth it, I have a lint CI job that takes 20 seconds so 10 seconds is a noticeable difference.

I'm not sure if this is best the way to code it, so any feedback would be good :)