### PR TITLE
Ensures GitHub is available prior to downloading the runner

### DIFF
--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
@@ -55,6 +55,9 @@ RUNNER_DOWNLOAD_URL=$(<./RUNNER_DOWNLOAD_URL)
 RUNNER_LABELS=$(<./RUNNER_LABELS)
 RUNNER_GROUP=$(<./RUNNER_GROUP)
 
+# Wait until we can connect to GitHub
+until ping -c1 github.com &>/dev/null; do :; done
+
 # Download the runner if the archive does not already exist
 if [ ! -f $ACTIONS_RUNNER_ARCHIVE ]; then
   curl -o $ACTIONS_RUNNER_ARCHIVE -L $RUNNER_DOWNLOAD_URL


### PR DESCRIPTION
The changes in this PR ensures that we do not attempt downloading the runner or setting up the runner until we have verified that the virtual machine is able to contact GitHub.

Failure to communicate with github.com, e.g. because the virtual machine did not have an Internet connection, would previously result in an error in the script, at which point the virtual machine would reboot. This could result in a boot loop if we were unable to communicate with github.com for a long period.