### PR TITLE
Use curl HEAD request to determine github's availability

### DIFF
--- a/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
+++ b/Packages/VirtualMachine/Sources/VirtualMachineResourcesServiceEphemeral/Resources/start.command
@@ -56,7 +56,7 @@ RUNNER_LABELS=$(<./RUNNER_LABELS)
 RUNNER_GROUP=$(<./RUNNER_GROUP)
 
 # Wait until we can connect to GitHub
-until ping -c1 github.com &>/dev/null; do :; done
+until curl -Is https://github.com &>/dev/null; do :; done
 
 # Download the runner if the archive does not already exist
 if [ ! -f $ACTIONS_RUNNER_ARCHIVE ]; then


### PR DESCRIPTION
# Description

Changes the Github availability check from `ping` to `curl`: In some circumstances, `ping` may be blocked, but `curl` works just fine.
Since we use `curl` later in the script to download the runner, this PR updates the check to use a `HEAD` request to determine Github's availability.

# Additional Information

* Original discussion: https://github.com/shapehq/tartelet/pull/56#issuecomment-1905733038