### PR TITLE
Checks if virtual machine can be started

### DIFF
--- a/Packages/VirtualMachine/Sources/VirtualMachineData/TartVirtualMachine.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineData/TartVirtualMachine.swift
@@ -5,6 +5,9 @@ public final class TartVirtualMachine: VirtualMachine {
     public var name: String {
         vmName
     }
+    public var canStart: Bool {
+        true
+    }
 
     private let tart: Tart
     private let vmName: String

--- a/Packages/VirtualMachine/Sources/VirtualMachineDomain/SSH/SSHConnectingVirtualMachine.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineDomain/SSH/SSHConnectingVirtualMachine.swift
@@ -34,6 +34,9 @@ public final class SSHConnectingVirtualMachine<SSHClientType: SSHClient>: Virtua
     public var name: String {
         virtualMachine.name
     }
+    public var canStart: Bool {
+        virtualMachine.canStart
+    }
 
     private let logger: Logger
     private let virtualMachine: VirtualMachine

--- a/Packages/VirtualMachine/Sources/VirtualMachineDomain/VirtualMachine.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineDomain/VirtualMachine.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public protocol VirtualMachine {
     var name: String { get }
+    var canStart: Bool { get }
     func start() async throws
     func clone(named newName: String) async throws -> VirtualMachine
     func delete() async throws

--- a/Packages/VirtualMachine/Sources/VirtualMachineDomain/VirtualMachineFleet.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineDomain/VirtualMachineFleet.swift
@@ -19,6 +19,9 @@ public final class VirtualMachineFleet {
         guard !isStarted else {
             return
         }
+        guard baseVirtualMachine.canStart else {
+            return
+        }
         isStarted = true
         for index in 0 ..< numberOfMachines {
             let name = baseVirtualMachine.name + "-\(index + 1)"

--- a/Tartelet/Sources/SettingsVirtualMachine.swift
+++ b/Tartelet/Sources/SettingsVirtualMachine.swift
@@ -11,6 +11,14 @@ struct SettingsVirtualMachine<SettingsStoreType: SettingsStore>: VirtualMachineD
             fatalError("Cannot get name of virtual machine because none has been selected in settings")
         }
     }
+    var canStart: Bool {
+        switch settingsStore.virtualMachine {
+        case .virtualMachine:
+            return true
+        case .unknown:
+            return false
+        }
+    }
 
     let tart: Tart
     let settingsStore: SettingsStoreType


### PR DESCRIPTION
Only start a virtual machine if it reports that it can be started.

This addresses an issue where Tartelet would crash on launch if "Start Virtual Machines on App Launch" was enabled but no virtual machine was selected. In this case, Tartelet would crash with the following error:

> Cannot get the name of the virtual machine because none has been selected in settings

Types conforming to the VirtualMachine protocol must now specify if the virtual machine can be started, and as such, SettingsVirtualMachine can specify that it cannot be started if no valid setting has been selected.