### PR TITLE
Checks if process is running before terminating

### DIFF
--- a/Packages/Shell/Sources/ShellData/ProcessShell.swift
+++ b/Packages/Shell/Sources/ShellData/ProcessShell.swift
@@ -26,7 +26,9 @@ public struct ProcessShell: Shell {
             }
             return String(data: data, encoding: .utf8) ?? ""
         } onCancel: {
-            sendableProcess.process.terminate()
+            if sendableProcess.process.isRunning {
+                sendableProcess.process.terminate()
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes a bug where Tartelet would crash when ProcessShell attempted terminating a process that wasn't running.