### PR TITLE
add post-config script

### DIFF
--- a/Packages/VirtualMachine/Sources/VirtualMachineDomain/GitHubActionsRunner/GitHubActionsRunnerSSHConnectionHandler.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineDomain/GitHubActionsRunner/GitHubActionsRunnerSSHConnectionHandler.swift
@@ -108,6 +108,13 @@ cd \\$ACTIONS_RUNNER_DIRECTORY
   --runnergroup "\(configuration.runnerGroup)"\\\\
   --work "_work"\\\\
   --token "\(runnerToken.rawValue)"
+
+# Run post-config script.
+POST_CONFIG_SCRIPT_PATH="\\$HOME/.tartelet/post-config.sh"
+if [ -f "\\$POST_CONFIG_SCRIPT_PATH" ]; then
+  bash "\\$POST_CONFIG_SCRIPT_PATH"
+fi
+
 ./run.sh
 EOF
 """)


### PR DESCRIPTION
Adding support for a `post-config` script that runs during GH runner setup.

## Motivation and Context
I need to modify the github runner's binary to modify its `actions/cache` behavior [like this](https://gha-cache-server.falcondev.io/getting-started) and figured a post-config script could be generally useful.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
