### PR TITLE
Fix Tart home folder path

### DIFF
--- a/Packages/Settings/Sources/SettingsUI/Internal/VirtualMachineSettings/TartHomeFolderPicker.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/VirtualMachineSettings/TartHomeFolderPicker.swift
@@ -6,7 +6,7 @@ struct TartHomeFolderPicker: View {
 
     private var folderPath: String {
         if let folderURL {
-            folderURL.path()
+            folderURL.path(percentEncoded: false)
         } else {
             L10n.Settings.VirtualMachine.TartHome.placeholder
         }

--- a/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
@@ -7,7 +7,7 @@ public struct Tart {
         guard let homeFolderURL = homeProvider.homeFolderURL else {
             return nil
         }
-        return ["TART_HOME": homeFolderURL.absoluteString]
+        return ["TART_HOME": homeFolderURL.path(percentEncoded: false)]
     }
 
     public init(homeProvider: TartHomeProvider, shell: Shell) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixing file paths for Tart home folder

## Motivation and Context

Using a custom Tart home folder does not currently work.

## Screenshots (if appropriate):

Using `path()` without `path(percentEncoded: false)` is causing paths with spaces to be percent encoded in the app UI:

![CleanShot 2025-03-14 at 23 09 31@2x](https://github.com/user-attachments/assets/54dddc22-f12c-44bb-a414-b07340297941)

Using `absoluteString` is causing the file path to have `file://` which does not work so the VM never starts.

![CleanShot 2025-03-14 at 22 55 54@2x](https://github.com/user-attachments/assets/5f7c8fb8-df31-4958-bf3b-3003292b8b41)

![CleanShot 2025-03-14 at 23 11 37@2x](https://github.com/user-attachments/assets/e5c82fdc-3766-4191-991f-749c5fec734c)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
