### PR TITLE
mount ~/.tart/cache directory when running vms

### DIFF
--- a/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ShellDomain
 
 public struct Tart {
@@ -20,7 +21,13 @@ public struct Tart {
     }
 
     public func run(name: String) async throws {
-        try await executeCommand(withArguments: ["run", name])
+        let homeFolderURL = homeProvider.homeFolderURL ??
+            FileManager.default.homeDirectoryForCurrentUser.appending(component: ".tart")
+        let cacheFolder = homeFolderURL.appendingPathComponent("cache")
+        if !FileManager.default.fileExists(atPath: cacheFolder.path) {
+            try FileManager.default.createDirectory(atPath: cacheFolder.path, withIntermediateDirectories: true)
+        }
+        try await executeCommand(withArguments: ["run", "--dir=cache:\(cacheFolder.path())", name])
     }
 
     public func delete(name: String) async throws {


### PR DESCRIPTION
I'm building a project with 2-3 GB of DerivedData and SPM cache, which doesn't work well getting tarballed and shipped to/from the Github cache, so I'm exploring more performant options. I still need to think through lock type stuff for a good solution here, but having a persistent directory from the host available on the VM is a solid start for me here :)

## Description
Creates a `cache` directory in the tart home and mounts it on run in virtual machines at `/Volumes/My Shared Files/cache`.

## Motivation and Context
See above but basically I want to cache files between builds to speed up SPM

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
