### PR TITLE
Add a new runner name field to the Runner settings

### DIFF
--- a/Packages/Settings/Sources/SettingsData/AppStorageSettingsStore.swift
+++ b/Packages/Settings/Sources/SettingsData/AppStorageSettingsStore.swift
@@ -14,6 +14,7 @@ public final class AppStorageSettingsStore: SettingsStore {
         static let gitHubRunnerDisableUpdates = "gitHubRunnerDisableUpdates"
         static let gitHubRunnerLabels = "gitHubRunnerLabels"
         static let gitHubRunnerGroup = "gitHubRunnerGroup"
+        static let gitHubRunnerName = "gitHubRunnerName"
         static let githubRunnerScope = "githubRunnerScope"
     }
 
@@ -122,6 +123,17 @@ public final class AppStorageSettingsStore: SettingsStore {
         set {
             withMutation(keyPath: \.gitHubRunnerGroup) {
                 userDefaults.setValue(newValue, forKey: AppStorageKey.gitHubRunnerGroup)
+            }
+        }
+    }
+    public var gitHubRunnerName: String {
+        get {
+            access(keyPath: \.gitHubRunnerName)
+            return userDefaults.string(forKey: AppStorageKey.gitHubRunnerName) ?? ""
+        }
+        set {
+            withMutation(keyPath: \.gitHubRunnerName) {
+                userDefaults.setValue(newValue, forKey: AppStorageKey.gitHubRunnerName)
             }
         }
     }

--- a/Packages/Settings/Sources/SettingsDomain/SettingsStore.swift
+++ b/Packages/Settings/Sources/SettingsDomain/SettingsStore.swift
@@ -11,5 +11,6 @@ public protocol SettingsStore: AnyObject {
     var gitHubRunnerDisableUpdates: Bool { get set }
     var gitHubRunnerLabels: String { get set }
     var gitHubRunnerGroup: String { get set }
+    var gitHubRunnerName: String { get set }
     var githubRunnerScope: GitHubRunnerScope { get set }
 }

--- a/Packages/Settings/Sources/SettingsDomain/VirtualMachine.swift
+++ b/Packages/Settings/Sources/SettingsDomain/VirtualMachine.swift
@@ -27,6 +27,15 @@ public enum VirtualMachine: RawRepresentable, Hashable {
             self = .unknown
         }
     }
+
+    public var name: String {
+        switch self {
+        case .unknown:
+            return "Unknown"
+        case .virtualMachine(let name):
+            return name
+        }
+    }
 }
 
 private extension VirtualMachine {

--- a/Packages/Settings/Sources/SettingsUI/Internal/GitHubRunnerSettings/GitHubRunnerSettingsView.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/GitHubRunnerSettings/GitHubRunnerSettingsView.swift
@@ -10,6 +10,13 @@ struct GitHubRunnerSettingsView<SettingsStoreType: SettingsStore & Observable>: 
         Form {
             Section {
                 TextField(
+                    L10n.Settings.GithubRunner.name,
+                    text: $settingsStore.gitHubRunnerName,
+                    prompt: Text(githubRunnerNamePrompt)
+                )
+                .disabled(!isSettingsEnabled)
+
+                TextField(
                     L10n.Settings.GithubRunner.labels,
                     text: $settingsStore.gitHubRunnerLabels,
                     prompt: Text(L10n.Settings.GithubRunner.Labels.prompt)
@@ -35,5 +42,14 @@ struct GitHubRunnerSettingsView<SettingsStoreType: SettingsStore & Observable>: 
             }
         }
         .formStyle(.grouped)
+    }
+
+    private var githubRunnerNamePrompt: String {
+        switch settingsStore.virtualMachine {
+            case .unknown:
+                return L10n.Settings.GithubRunner.Name.prompt
+            case .virtualMachine(let name):
+                return name
+        }
     }
 }

--- a/Packages/Settings/Sources/SettingsUI/Internal/L10n.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/L10n.swift
@@ -91,6 +91,8 @@ internal enum L10n {
       internal static let group = L10n.tr("Localizable", "settings.github_runner.group", fallback: "Group")
       /// Labels
       internal static let labels = L10n.tr("Localizable", "settings.github_runner.labels", fallback: "Labels")
+      /// Name
+      internal static let name = L10n.tr("Localizable", "settings.github_runner.name", fallback: "Name")
       internal enum DisableUpdates {
         /// This is meant to be used when a fixed version is pre-installed, otherwise Tartelet will install the latest version when the VM starts.
         internal static let subtitle = L10n.tr("Localizable", "settings.github_runner.disableUpdates.subtitle", fallback: "This is meant to be used when a fixed version is pre-installed, otherwise Tartelet will install the latest version when the VM starts.")
@@ -104,6 +106,12 @@ internal enum L10n {
         internal static let footer = L10n.tr("Localizable", "settings.github_runner.labels.footer", fallback: "Comma-separated list of labels.")
         /// comma,separated,list
         internal static let prompt = L10n.tr("Localizable", "settings.github_runner.labels.prompt", fallback: "comma,separated,list")
+      }
+      internal enum Name {
+        /// Base name for runners.
+        internal static let footer = L10n.tr("Localizable", "settings.github_runner.name.footer", fallback: "Base name for runners.")
+        /// Optional custom name, e.g., My CI Runner
+        internal static let prompt = L10n.tr("Localizable", "settings.github_runner.name.prompt", fallback: "Optional custom name, e.g., My CI Runner")
       }
     }
     internal enum RunnerScope {

--- a/Packages/Settings/Sources/SettingsUI/Internal/Localizable.strings
+++ b/Packages/Settings/Sources/SettingsUI/Internal/Localizable.strings
@@ -48,6 +48,9 @@
 "settings.github_runner.labels.footer" = "Comma-separated list of labels.";
 "settings.github_runner.group" = "Group";
 "settings.github_runner.group.prompt" = "acme";
+"settings.github_runner.name" = "Name";
+"settings.github_runner.name.prompt" = "Optional custom name, e.g., My CI Runner";
+"settings.github_runner.name.footer" = "Base name for runners.";
 
 "settings.runner_scope.organization" = "Organization";
 "settings.runner_scope.repository" = "Repository";

--- a/Packages/VirtualMachine/Sources/VirtualMachineDomain/GitHubActionsRunner/GitHubActionsRunnerConfiguration.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineDomain/GitHubActionsRunner/GitHubActionsRunnerConfiguration.swift
@@ -5,4 +5,5 @@ public protocol GitHubActionsRunnerConfiguration {
     var runnerScope: GitHubRunnerScope { get }
     var runnerLabels: String { get }
     var runnerGroup: String { get }
+    var runnerName: String { get }
 }

--- a/Packages/VirtualMachine/Sources/VirtualMachineDomain/GitHubActionsRunner/GitHubActionsRunnerSSHConnectionHandler.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineDomain/GitHubActionsRunner/GitHubActionsRunnerSSHConnectionHandler.swift
@@ -104,7 +104,7 @@ cd \\$ACTIONS_RUNNER_DIRECTORY
   --ephemeral\\\\
   --replace\\\\
   --labels "\(configuration.runnerLabels)"\\\\
-  --name "\(virtualMachine.name)"\\\\
+  --name "\(runnerName(for: virtualMachine))"\\\\
   --runnergroup "\(configuration.runnerGroup)"\\\\
   --work "_work"\\\\
   --token "\(runnerToken.rawValue)"\\\\
@@ -114,6 +114,25 @@ EOF
 """)
         try await connection.executeCommand("chmod +x \(startRunnerScriptFilePath)")
         try await connection.executeCommand("open -a Terminal \(startRunnerScriptFilePath)")
+    }
+    private func runnerName(for virtualMachine: VirtualMachine) -> String {
+        let configuredRunnerName = configuration.runnerName
+
+        // If no custom runner name is configured, use the VM name as-is
+        if configuredRunnerName.isEmpty {
+            return virtualMachine.name
+        }
+
+        // Extract the index suffix from VM names like "baseVM-1", "baseVM-2"
+        let vmName = virtualMachine.name
+        if let lastDashIndex = vmName.lastIndex(of: "-") {
+            let indexString = String(vmName[vmName.index(after: lastDashIndex)...])
+            if !indexString.isEmpty, Int(indexString) != nil {
+                return "\(configuredRunnerName) \(indexString)"
+            }
+        }
+        // Fallback to just the runner name if we can't extract an index
+        return configuredRunnerName
     }
 }
 

--- a/Tartelet/Sources/SettingsGitHubActionsRunnerConfiguration.swift
+++ b/Tartelet/Sources/SettingsGitHubActionsRunnerConfiguration.swift
@@ -18,4 +18,7 @@ struct SettingsGitHubActionsRunnerConfiguration<
     var runnerGroup: String {
         settingsStore.gitHubRunnerGroup
     }
+    var runnerName: String {
+        settingsStore.gitHubRunnerName
+    }
 }


### PR DESCRIPTION
## Description
This PR proposes adding a new setting in the "Runners" tab that allows controlling the base name that's used for runners.

## Motivation and Context
I had this functionality in other CI tools that I've used, and it makes the runner names in GitHub much nicer if they are readable, and not just hyphen-delimited identifiers (but you can still have this if you'd like!).

It's nice to have nice things.

## Screenshots (if appropriate):
![CleanShot 2025-06-08 at 14 59 48@2x](https://github.com/user-attachments/assets/84563150-a787-422a-b3bf-2258839b50ea)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
