### PR TITLE
Add a TARTELET_RUN_OPTIONS environment variable

### DIFF
--- a/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
@@ -27,7 +27,12 @@ public struct Tart {
         if !FileManager.default.fileExists(atPath: cacheFolder.path) {
             try FileManager.default.createDirectory(atPath: cacheFolder.path, withIntermediateDirectories: true)
         }
-        try await executeCommand(withArguments: ["run", "--dir=cache:\(cacheFolder.path())", name])
+        var runArgs =  ["run", "--dir=cache:\(cacheFolder.path())"]
+        if let tartRunOptions = ProcessInfo.processInfo.environment["TARTELET_RUN_OPTIONS"] {
+            runArgs.append(tartRunOptions)
+        }
+        runArgs.append(name)
+        try await executeCommand(withArguments: runArgs)
     }
 
     public func delete(name: String) async throws {


### PR DESCRIPTION
Add a TARTELET_RUN_OPTIONS environment variable to specific run options for tart.

Tart offers a number of options for the run command (such as `--nested` which enables nested virtualisation), butthey are hardcoded in Tartelet, and I could not find any easy way of setting them.

## Description

Small PR which modifies the VirtualMachine package and read the environment variable `TARTELET_RUN_OPTIONS` when starting a new VM.  If the variable is found, then its content is appended to the `tart run ...` command.

## Motivation and Context

My build require the tart option `--nested` to enable nested virtualisation.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
