### PR TITLE
Adds a value for the NSLocalNetworkUsageDescription Info.plist key

### DIFF
--- a/xcconfigs/General.xcconfig
+++ b/xcconfigs/General.xcconfig
@@ -7,3 +7,4 @@ CODE_SIGN_ENTITLEMENTS = Tartelet/Supporting files/Tartelet.entitlements
 MACOSX_DEPLOYMENT_TARGET = 14.0
 ENABLE_HARDENED_RUNTIME = YES
 INFOPLIST_KEY_LSApplicationCategoryType = public.app-category.developer-tools
+INFOPLIST_KEY_NSLocalNetworkUsageDescription = Used to connect to macOS VMs over the local network


### PR DESCRIPTION
@simonbs I tried to test this locally, but I'm having issues with code signing using my Apple ID and bundle ID. Would you be able to generate a build of the app from this branch that I could test and see if it fixes the issues?

## Description

I'm having some issues with Tartelet when trying to run it on a Mac running macOS 15.5. For some reason, the "Local Network Access" setting that Tartelet needs in order to connect to `tart` runners does not persist across restarts.

(Weirdly, the toggle button in `System Settings > Privacy & Security > Local Network` does still stay on, but I have to toggle it off and back on again in order to get Tartelet working.)

## Motivation and Context

I have a hunch that this may be caused by Tartelet not having a value for `NSLocalNetworkUsageDescription` in its Info.plist. Apparently this is a new setting that is now required (supposedly as of macOS 15, but I'm not seeing these problems on macOS 15.1, so maybe it was just recently added as a requirement).

This PR is to add a value for that in hopes that it will fix the issue.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)