### PR TITLE
Add option to disable default runner labels

### DIFF
--- a/Packages/Settings/Sources/SettingsData/AppStorageSettingsStore.swift
+++ b/Packages/Settings/Sources/SettingsData/AppStorageSettingsStore.swift
@@ -15,6 +15,7 @@ public final class AppStorageSettingsStore: SettingsStore {
         static let gitHubRunnerLabels = "gitHubRunnerLabels"
         static let gitHubRunnerGroup = "gitHubRunnerGroup"
         static let gitHubRunnerName = "gitHubRunnerName"
+        static let gitHubRunnerDisableDefaultLabels = "gitHubRunnerDisableDefaultLabels"
         static let githubRunnerScope = "githubRunnerScope"
     }
 
@@ -134,6 +135,17 @@ public final class AppStorageSettingsStore: SettingsStore {
         set {
             withMutation(keyPath: \.gitHubRunnerName) {
                 userDefaults.setValue(newValue, forKey: AppStorageKey.gitHubRunnerName)
+            }
+        }
+    }
+    public var gitHubRunnerDisableDefaultLabels: Bool {
+        get {
+            access(keyPath: \.gitHubRunnerDisableDefaultLabels)
+            return userDefaults.bool(forKey: AppStorageKey.gitHubRunnerDisableDefaultLabels)
+        }
+        set {
+            withMutation(keyPath: \.gitHubRunnerDisableDefaultLabels) {
+                userDefaults.setValue(newValue, forKey: AppStorageKey.gitHubRunnerDisableDefaultLabels)
             }
         }
     }

--- a/Packages/Settings/Sources/SettingsDomain/SettingsStore.swift
+++ b/Packages/Settings/Sources/SettingsDomain/SettingsStore.swift
@@ -12,5 +12,6 @@ public protocol SettingsStore: AnyObject {
     var gitHubRunnerLabels: String { get set }
     var gitHubRunnerGroup: String { get set }
     var gitHubRunnerName: String { get set }
+    var gitHubRunnerDisableDefaultLabels: Bool { get set }
     var githubRunnerScope: GitHubRunnerScope { get set }
 }

--- a/Packages/Settings/Sources/SettingsUI/Internal/GitHubRunnerSettings/GitHubRunnerSettingsView.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/GitHubRunnerSettings/GitHubRunnerSettingsView.swift
@@ -15,7 +15,11 @@ struct GitHubRunnerSettingsView<SettingsStoreType: SettingsStore & Observable>: 
                     prompt: Text(githubRunnerNamePrompt)
                 )
                 .disabled(!isSettingsEnabled)
-
+                Toggle(isOn: $settingsStore.gitHubRunnerDisableDefaultLabels) {
+                    Text(L10n.Settings.GithubRunner.disableDefaultLabels)
+                }
+                .disabled(!isSettingsEnabled)
+                
                 TextField(
                     L10n.Settings.GithubRunner.labels,
                     text: $settingsStore.gitHubRunnerLabels,

--- a/Packages/Settings/Sources/SettingsUI/Internal/L10n.swift
+++ b/Packages/Settings/Sources/SettingsUI/Internal/L10n.swift
@@ -101,6 +101,7 @@ internal enum L10n {
         /// acme
         internal static let prompt = L10n.tr("Localizable", "settings.github_runner.group.prompt", fallback: "acme")
       }
+      internal static let disableDefaultLabels = L10n.tr("Localizable", "settings.github_runner.disableDefaultLabels", fallback: "Disable default labels")
       internal enum Labels {
         /// Comma-separated list of labels.
         internal static let footer = L10n.tr("Localizable", "settings.github_runner.labels.footer", fallback: "Comma-separated list of labels.")

--- a/Packages/Settings/Sources/SettingsUI/Internal/Localizable.strings
+++ b/Packages/Settings/Sources/SettingsUI/Internal/Localizable.strings
@@ -41,6 +41,7 @@
 "settings.github.create_app" = "Create GitHub App";
 
 "settings.github_runner" = "Runner";
+"settings.github_runner.disableDefaultLabels" = "Disable default labels"
 "settings.github_runner.disableUpdates" = "Disable runner auto-update";
 "settings.github_runner.disableUpdates.subtitle" = "This is meant to be used when a fixed version is pre-installed, otherwise Tartelet will install the latest version when the VM starts.";
 "settings.github_runner.labels" = "Labels";

--- a/Packages/VirtualMachine/Sources/VirtualMachineDomain/GitHubActionsRunner/GitHubActionsRunnerConfiguration.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineDomain/GitHubActionsRunner/GitHubActionsRunnerConfiguration.swift
@@ -1,6 +1,7 @@
 import GitHubDomain
 
 public protocol GitHubActionsRunnerConfiguration {
+    var runnerDisableDefaultLabels: Bool { get }
     var runnerDisableUpdates: Bool { get }
     var runnerScope: GitHubRunnerScope { get }
     var runnerLabels: String { get }

--- a/Packages/VirtualMachine/Sources/VirtualMachineDomain/GitHubActionsRunner/GitHubActionsRunnerSSHConnectionHandler.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineDomain/GitHubActionsRunner/GitHubActionsRunnerSSHConnectionHandler.swift
@@ -108,7 +108,8 @@ cd \\$ACTIONS_RUNNER_DIRECTORY
   --runnergroup "\(configuration.runnerGroup)"\\\\
   --work "_work"\\\\
   --token "\(runnerToken.rawValue)"\\\\
-  \(configuration.runnerDisableUpdates ? "--disableupdate" : "")
+  \(configuration.runnerDisableUpdates ? "--disableupdate" : "")\\\\
+  \(configuration.runnerDisableDefaultLabels ? "--no-default-labels" : "")
 ./run.sh
 EOF
 """)

--- a/Tartelet/Sources/SettingsGitHubActionsRunnerConfiguration.swift
+++ b/Tartelet/Sources/SettingsGitHubActionsRunnerConfiguration.swift
@@ -6,6 +6,9 @@ struct SettingsGitHubActionsRunnerConfiguration<
     SettingsStoreType: SettingsStore
 >: GitHubActionsRunnerConfiguration {
     let settingsStore: SettingsStoreType
+    var runnerDisableDefaultLabels: Bool {
+        settingsStore.gitHubRunnerDisableDefaultLabels
+    }
     var runnerDisableUpdates: Bool {
         settingsStore.gitHubRunnerDisableUpdates
     }


### PR DESCRIPTION
## Description
Add option to disable default runner labels

## Motivation and Context
For my use case, I need to remove the default labels on the created runners do they are not picked up and used by workflows that do not specifically require VM runners.  

This update enables core functionality that exists for setting up self-hosted GitHub runners. ([--no-default-labels](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#choosing-self-hosted-runners))

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
