### PR TITLE
Wait for VM when retrieving IP address

### DIFF
--- a/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
@@ -45,7 +45,7 @@ public struct Tart {
     }
 
     public func getIPAddress(ofVirtualMachineNamed name: String) async throws -> String {
-        let result = try await executeCommand(withArguments: ["ip", name])
+        let result = try await executeCommand(withArguments: ["ip", name, "--wait", "5"])
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }


### PR DESCRIPTION
## Description
When this function is initially called it’s highly unlikely that the target VM has had the chance to start yet. As such, it’s unlikely to have an IP assigned. By using Tart’s built-in `--wait` flag we can give the VM some time which makes IP resolution more reliable.

## Motivation and Context
This PR makes VM IP resolution more reliable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
