### PR TITLE
Forward TARTELET_RUN_OPTIONS to tart as separate arguments

### DIFF
--- a/Packages/VirtualMachine/Package.swift
+++ b/Packages/VirtualMachine/Package.swift
@@ -32,6 +32,9 @@ let package = Package(
             .product(name: "GitHubDomain", package: "GitHub"),
             .product(name: "LoggingDomain", package: "Logging"),
             .product(name: "SSHDomain", package: "SSH")
+        ]),
+        .testTarget(name: "VirtualMachineDataTests", dependencies: [
+            "VirtualMachineData"
         ])
     ]
 )

--- a/Packages/VirtualMachine/Sources/VirtualMachineData/Internal/ShellWordSplitter.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineData/Internal/ShellWordSplitter.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Splits a command-option string into argv elements the way a POSIX shell would,
+/// honoring single quotes, double quotes, and backslash escapes.
+///
+/// Used to forward `TARTELET_RUN_OPTIONS` to `tart run` as separate arguments:
+/// appending the raw string as a single argument makes `tart` reject it as one
+/// unknown option (e.g. `--net-softnet --net-softnet-allow=…`). Naive splitting on
+/// spaces would in turn corrupt any value containing a quoted space, such as a
+/// `--dir=` mount whose path has spaces.
+enum ShellWordSplitter {
+    static func split(_ string: String) -> [String] {
+        var words: [String] = []
+        var current = ""
+        // Tracks whether the current run of characters has started a word, so an
+        // explicit empty quote ("" or '') still yields one empty argument.
+        var hasWord = false
+        var quote: Character?
+        var escaped = false
+
+        for character in string {
+            if escaped {
+                current.append(character)
+                escaped = false
+                continue
+            }
+
+            switch quote {
+            case "'":
+                // Single quotes are literal: no escapes, no nesting.
+                if character == "'" {
+                    quote = nil
+                } else {
+                    current.append(character)
+                }
+            case "\"":
+                // Double quotes allow backslash to escape the next character.
+                if character == "\\" {
+                    escaped = true
+                } else if character == "\"" {
+                    quote = nil
+                } else {
+                    current.append(character)
+                }
+            default:
+                switch character {
+                case "'", "\"":
+                    quote = character
+                case "\\":
+                    escaped = true
+                case " ", "\t", "\n", "\r":
+                    if hasWord {
+                        words.append(current)
+                        current = ""
+                        hasWord = false
+                    }
+                    continue
+                default:
+                    current.append(character)
+                }
+            }
+            hasWord = true
+        }
+
+        if hasWord {
+            words.append(current)
+        }
+        return words
+    }
+}

--- a/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
@@ -29,7 +29,10 @@ public struct Tart {
         }
         var runArgs =  ["run", "--dir=cache:\(cacheFolder.path())"]
         if let tartRunOptions = ProcessInfo.processInfo.environment["TARTELET_RUN_OPTIONS"] {
-            runArgs.append(tartRunOptions)
+            // Shell-tokenize into separate argv elements; appending the whole
+            // string as one argument makes `tart run` reject it as a single
+            // unknown option (e.g. "--net-softnet --net-softnet-allow=…").
+            runArgs.append(contentsOf: ShellWordSplitter.split(tartRunOptions))
         }
         runArgs.append(name)
         try await executeCommand(withArguments: runArgs)

--- a/Packages/VirtualMachine/Tests/VirtualMachineDataTests/ShellWordSplitterTests.swift
+++ b/Packages/VirtualMachine/Tests/VirtualMachineDataTests/ShellWordSplitterTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import VirtualMachineData
+
+final class ShellWordSplitterTests: XCTestCase {
+    func testEmptyStringYieldsNoWords() {
+        XCTAssertEqual(ShellWordSplitter.split(""), [])
+    }
+
+    func testWhitespaceOnlyYieldsNoWords() {
+        XCTAssertEqual(ShellWordSplitter.split("   \t \n "), [])
+    }
+
+    func testSingleWord() {
+        XCTAssertEqual(ShellWordSplitter.split("--net-softnet"), ["--net-softnet"])
+    }
+
+    func testSplitsOnWhitespace() {
+        XCTAssertEqual(
+            ShellWordSplitter.split("--net-softnet --net-softnet-allow=192.168.2.0/24"),
+            ["--net-softnet", "--net-softnet-allow=192.168.2.0/24"]
+        )
+    }
+
+    func testCollapsesRunsOfWhitespace() {
+        XCTAssertEqual(
+            ShellWordSplitter.split("  a\t\tb   c  "),
+            ["a", "b", "c"]
+        )
+    }
+
+    func testDoubleQuotesPreserveSpaces() {
+        XCTAssertEqual(
+            ShellWordSplitter.split("--dir=\"cache:/My Mount\""),
+            ["--dir=cache:/My Mount"]
+        )
+    }
+
+    func testSingleQuotesPreserveSpaces() {
+        XCTAssertEqual(
+            ShellWordSplitter.split("'a b c'"),
+            ["a b c"]
+        )
+    }
+
+    func testSingleQuotesAreLiteral() {
+        XCTAssertEqual(
+            ShellWordSplitter.split("'a\\b'"),
+            ["a\\b"]
+        )
+    }
+
+    func testBackslashEscapesSpace() {
+        XCTAssertEqual(
+            ShellWordSplitter.split("a\\ b"),
+            ["a b"]
+        )
+    }
+
+    func testBackslashEscapesQuoteCharacter() {
+        XCTAssertEqual(
+            ShellWordSplitter.split("a\\\"b"),
+            ["a\"b"]
+        )
+    }
+
+    func testEscapedQuoteInsideDoubleQuotes() {
+        XCTAssertEqual(
+            ShellWordSplitter.split("\"a\\\"b\""),
+            ["a\"b"]
+        )
+    }
+
+    func testAdjacentQuotedAndUnquotedConcatenate() {
+        XCTAssertEqual(
+            ShellWordSplitter.split("--label='self hosted'macos"),
+            ["--label=self hostedmacos"]
+        )
+    }
+
+    func testEmptyQuotesYieldOneEmptyArgument() {
+        XCTAssertEqual(ShellWordSplitter.split("''"), [""])
+        XCTAssertEqual(ShellWordSplitter.split("\"\""), [""])
+    }
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

TARTELET_RUN_OPTIONS was appended to `tart run` as a single argv element, so any value with more than one flag was rejected as one unknown option 

The value is now shell-tokenized into separate arguments via a small POSIX-style splitter that honors single/double quotes and backslash escapes, so a quoted value (such as a `--dir=` mount whose path contains spaces) is preserved instead of being split on every space.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It was not possible to enable softnet network isolation eg. (`--net-softnet --net-softnet-allow=<subnet>`) failed with `Unknown option '--net-softnet --net-softnet-allow=...'`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
