### PR TITLE
Spawn tart with an inherited environment and its bin dir on PATH

### DIFF
--- a/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
+++ b/Packages/VirtualMachine/Sources/VirtualMachineData/Tart.swift
@@ -4,12 +4,6 @@ import ShellDomain
 public struct Tart {
     private let homeProvider: TartHomeProvider
     private let shell: Shell
-    private var environment: [String: String]? {
-        guard let homeFolderURL = homeProvider.homeFolderURL else {
-            return nil
-        }
-        return ["TART_HOME": homeFolderURL.path(percentEncoded: false)]
-    }
 
     public init(homeProvider: TartHomeProvider, shell: Shell) {
         self.homeProvider = homeProvider
@@ -53,19 +47,32 @@ public struct Tart {
 private extension Tart {
     @discardableResult
     private func executeCommand(withArguments arguments: [String]) async throws -> String {
-        let locator = TartLocator(shell: shell)
-        let filePath = try locator.locate()
-        if let environment {
-            return try await shell.runExecutable(
-                atPath: filePath,
-                withArguments: arguments,
-                environment: environment
-            )
-        } else {
-            return try await shell.runExecutable(
-                atPath: filePath,
-                withArguments: arguments
-            )
+        let filePath = try TartLocator(shell: shell).locate()
+        return try await shell.runExecutable(
+            atPath: filePath,
+            withArguments: arguments,
+            environment: environment(forTartAt: filePath)
+        )
+    }
+
+    private func environment(forTartAt tartPath: String) -> [String: String] {
+        // Inherit the launching process's environment instead of replacing it.
+        // Spawning tart with an empty (or TART_HOME-only) environment left it
+        // without a usable PATH, so it could not find helpers it execs by name.
+        var environment = ProcessInfo.processInfo.environment
+        if let homeFolderURL = homeProvider.homeFolderURL {
+            environment["TART_HOME"] = homeFolderURL.path(percentEncoded: false)
         }
+        // tart execs helper binaries (e.g. `softnet` for `--net-softnet`) by name,
+        // resolving them through PATH. They are installed alongside the tart binary,
+        // so ensure tart's own directory is on PATH. This matters when Tartelet runs
+        // as a GUI app, whose launchd PATH omits e.g. the Homebrew bin directory.
+        let tartDirectory = (tartPath as NSString).deletingLastPathComponent
+        if let existingPath = environment["PATH"], !existingPath.isEmpty {
+            environment["PATH"] = tartDirectory + ":" + existingPath
+        } else {
+            environment["PATH"] = tartDirectory
+        }
+        return environment
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Inherit the launching process's environment instead of replacing it, overlay TART_HOME, and prepend the directory of the located tart binary to PATH. tart's helpers are installed alongside tart, so reusing the path we already resolve to launch tart makes them discoverable without hardcoding any install location.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

tart was spawned with a replaced environment containing at most TART_HOME, so the child process had no usable PATH. tart execs helper binaries by name and resolves them through PATH — most visibly `softnet` for `--net-softnet`, which failed with InitializationFailed("softnet not found in PATH") when Tartelet ran as a GUI app (whose launchd PATH omits e.g. the Homebrew bin directory).


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
